### PR TITLE
Add Simplified Chinese i18n support

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -56,10 +56,11 @@ namespace FluentTaskScheduler
 
         public App()
         {
-            // Force English language
+            // Apply persisted language, fallback to English.
             try
             {
-                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
+                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride =
+                    string.IsNullOrWhiteSpace(SS.Language) ? "en-US" : SS.Language;
             }
             catch { }
 
@@ -113,9 +114,9 @@ namespace FluentTaskScheduler
                             {
                                 var dialog = new ContentDialog
                                 {
-                                    Title = "Unhandled Exception",
+                                    Title = Services.LocalizationService.GetString("App.UnhandledException.Title", "Unhandled Exception"),
                                     Content = errorMessage,
-                                    CloseButtonText = "Close",
+                                    CloseButtonText = Services.LocalizationService.GetString("Dialog.Close", "Close"),
                                     XamlRoot = m_window.Content?.XamlRoot
                                 };
                                 await dialog.ShowAsync();
@@ -516,10 +517,12 @@ namespace FluentTaskScheduler
                     {
                         var dialog = new ContentDialog
                         {
-                            Title = "Update Available",
-                            Content = $"Version {result.NewVersion} has been downloaded and is ready to install.\nRestart now to apply the update?",
-                            PrimaryButtonText = "Restart Now",
-                            CloseButtonText = "Later",
+                            Title = Services.LocalizationService.GetString("App.UpdateAvailable.Title", "Update Available"),
+                            Content = string.Format(
+                                Services.LocalizationService.GetString("App.UpdateAvailable.Content", "Version {0} has been downloaded and is ready to install.\nRestart now to apply the update?"),
+                                result.NewVersion),
+                            PrimaryButtonText = Services.LocalizationService.GetString("Dialog.RestartNow", "Restart Now"),
+                            CloseButtonText = Services.LocalizationService.GetString("Dialog.Later", "Later"),
                             XamlRoot = m_window.Content?.XamlRoot,
                             RequestedTheme = SS.Theme
                         };

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -56,13 +56,8 @@ namespace FluentTaskScheduler
 
         public App()
         {
-            // Apply persisted language, fallback to English.
-            try
-            {
-                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride =
-                    string.IsNullOrWhiteSpace(SS.Language) ? "en-US" : SS.Language;
-            }
-            catch { }
+            Services.LocalizationService.Initialize();
+            Services.LocalizationService.LanguageChanged += LocalizationService_LanguageChanged;
 
             // Handle toast notification activation (e.g. clicking the "minimized to tray" notification)
             ToastNotificationManagerCompat.OnActivated += OnToastActivated;
@@ -75,6 +70,36 @@ namespace FluentTaskScheduler
             TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 #pragma warning restore CS8622
             this.UnhandledException += App_UnhandledException;
+        }
+
+        private void LocalizationService_LanguageChanged(object? sender, EventArgs e)
+        {
+            foreach (var rec in _windows)
+            {
+                try
+                {
+                    rec.Win.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        if (rec.Win.Content is Frame rootFrame)
+                        {
+                            if (rootFrame.Content is MainPage mainPage)
+                            {
+                                mainPage.RefreshLocalizedUi();
+                            }
+                            else
+                            {
+                                rootFrame.Navigate(typeof(MainPage));
+                            }
+                        }
+
+                        rec.Win.Title = GetWindowTitle(rec.Name);
+                    });
+                }
+                catch
+                {
+                    // Ignore window refresh issues and continue.
+                }
+            }
         }
 
         private void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEventArgs e)
@@ -114,9 +139,9 @@ namespace FluentTaskScheduler
                             {
                                 var dialog = new ContentDialog
                                 {
-                                    Title = Services.LocalizationService.GetString("App.UnhandledException.Title", "Unhandled Exception"),
+                                    Title = "Unhandled Exception",
                                     Content = errorMessage,
-                                    CloseButtonText = Services.LocalizationService.GetString("Dialog.Close", "Close"),
+                                    CloseButtonText = "Close",
                                     XamlRoot = m_window.Content?.XamlRoot
                                 };
                                 await dialog.ShowAsync();
@@ -300,7 +325,7 @@ namespace FluentTaskScheduler
             string name = _windowCounter == 1 ? "Window 1" : $"Window {_windowCounter}";
 
             var win = new Window();
-            win.Title = _windowCounter == 1 ? "FluentTaskScheduler" : $"FluentTaskScheduler — {name}";
+            win.Title = GetWindowTitle(name);
 
             var rec = new WindowRecord(name, win);
             _windows.Add(rec);
@@ -370,6 +395,17 @@ namespace FluentTaskScheduler
             };
 
             win.Activate();
+        }
+
+        private static string GetWindowTitle(string windowName)
+        {
+            string appTitle = Services.LocalizationService.GetString("App.WindowTitle", "FluentTaskScheduler");
+            if (string.Equals(windowName, "Window 1", StringComparison.OrdinalIgnoreCase))
+            {
+                return appTitle;
+            }
+
+            return $"{appTitle} — {windowName}";
         }
 
         private void AppWindow_Closing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
@@ -517,12 +553,14 @@ namespace FluentTaskScheduler
                     {
                         var dialog = new ContentDialog
                         {
-                            Title = Services.LocalizationService.GetString("App.UpdateAvailable.Title", "Update Available"),
+                            Title = Services.LocalizationService.GetString("Dialog.UpdateAvailable.Title", "Update Available"),
                             Content = string.Format(
-                                Services.LocalizationService.GetString("App.UpdateAvailable.Content", "Version {0} has been downloaded and is ready to install.\nRestart now to apply the update?"),
+                                Services.LocalizationService.GetString(
+                                    "Dialog.UpdateAvailable.ContentFormat",
+                                    "Version {0} has been downloaded and is ready to install.\nRestart now to apply the update?"),
                                 result.NewVersion),
-                            PrimaryButtonText = Services.LocalizationService.GetString("Dialog.RestartNow", "Restart Now"),
-                            CloseButtonText = Services.LocalizationService.GetString("Dialog.Later", "Later"),
+                            PrimaryButtonText = Services.LocalizationService.GetString("Dialog.UpdateAvailable.RestartNow", "Restart Now"),
+                            CloseButtonText = Services.LocalizationService.GetString("Dialog.Common.Later", "Later"),
                             XamlRoot = m_window.Content?.XamlRoot,
                             RequestedTheme = SS.Theme
                         };

--- a/DashboardPage.xaml
+++ b/DashboardPage.xaml
@@ -15,7 +15,7 @@
                 <Button x:Name="DashboardReloadBtn" Click="DashboardReload_Click" HorizontalAlignment="Right" Margin="0,0,0,-12">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <SymbolIcon Symbol="Refresh" />
-                        <TextBlock Text="Reload Dashboard" />
+                        <TextBlock Text="刷新仪表盘" />
                     </StackPanel>
                 </Button>
 
@@ -28,7 +28,7 @@
                     
                     <!-- Category Filter -->
                     <StackPanel Spacing="8">
-                        <TextBlock Text="Filter by category" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" Margin="4,0,0,0"/>
+                        <TextBlock Text="按分类筛选" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" Margin="4,0,0,0"/>
                         <ItemsControl ItemsSource="{x:Bind ViewModel.AvailableCategories, Mode=OneWay}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
@@ -48,7 +48,7 @@
 
                     <!-- Tag Filter -->
                     <StackPanel Grid.Column="1" Spacing="8">
-                        <TextBlock Text="Filter by tag" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" Margin="4,0,0,0"/>
+                        <TextBlock Text="按标签筛选" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" Margin="4,0,0,0"/>
                         <ItemsControl ItemsSource="{x:Bind ViewModel.AvailableTags, Mode=OneWay}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
@@ -79,15 +79,15 @@
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <FontIcon Glyph="&#xE8F1;" FontSize="16" Opacity="0.7"/>
-                                <TextBlock Text="Total Tasks" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="任务总数" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             </StackPanel>
                             <TextBlock Text="{x:Bind ViewModel.TotalTasks, Mode=OneWay}" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0"/>
                             <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,0" Opacity="0.7">
                                 <TextBlock Text="{x:Bind ViewModel.EnabledTasks, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
-                                <TextBlock Text="Active"/>
+                                <TextBlock Text="启用"/>
                                 <TextBlock Text="|" Opacity="0.3"/>
                                 <TextBlock Text="{x:Bind ViewModel.DisabledTasks, Mode=OneWay}" Foreground="LightGray"/>
-                                <TextBlock Text="Disabled"/>
+                                <TextBlock Text="禁用"/>
                             </StackPanel>
                         </StackPanel>
                     </Grid>
@@ -97,10 +97,10 @@
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <FontIcon Glyph="&#xE76F;" FontSize="16" Opacity="0.7" Foreground="MediumSeaGreen"/>
-                                <TextBlock Text="Running Now" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="正在运行" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             </StackPanel>
                             <TextBlock Text="{x:Bind ViewModel.RunningTasks, Mode=OneWay}" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0" Foreground="MediumSeaGreen"/>
-                            <TextBlock Text="Active processes" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Margin="0,4,0,0"/>
+                            <TextBlock Text="活跃进程" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Grid>
 
@@ -109,7 +109,7 @@
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <FontIcon Glyph="&#xE9D9;" FontSize="16" Opacity="0.7"/>
-                                <TextBlock Text="Health Score" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="健康评分" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             </StackPanel>
                             <TextBlock Text="{x:Bind ViewModel.HealthScore, Mode=OneWay}" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0" Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
                             <ProgressBar Value="{x:Bind ViewModel.HealthScore, Mode=OneWay}" Maximum="100" Margin="0,12,0,0" Height="4"/>
@@ -130,10 +130,10 @@
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <FontIcon Glyph="&#xE73E;" FontSize="16" Opacity="0.7" Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
-                                <TextBlock Text="Recent Success" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="近期成功" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             </StackPanel>
                             <TextBlock Text="{x:Bind ViewModel.LastRunSuccess, Mode=OneWay}" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0"/>
-                            <TextBlock Text="Last checked tasks" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Margin="0,4,0,0"/>
+                            <TextBlock Text="最近检查的任务" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Grid>
 
@@ -142,10 +142,10 @@
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <FontIcon Glyph="&#xE711;" FontSize="16" Opacity="0.7" Foreground="{ThemeResource SystemFillColorCriticalBrush}"/>
-                                <TextBlock Text="Recent Failures" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="近期失败" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             </StackPanel>
                             <TextBlock Text="{x:Bind ViewModel.LastRunFailed, Mode=OneWay}" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0" Foreground="{ThemeResource SystemFillColorCriticalBrush}"/>
-                            <TextBlock Text="Attention needed" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Margin="0,4,0,0"/>
+                            <TextBlock Text="需要关注" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Grid>
 
@@ -156,7 +156,7 @@
                 <!-- Currently Running Tasks -->
                 <StackPanel Spacing="6">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="Currently Running" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                        <TextBlock Text="当前运行中" Style="{StaticResource SubtitleTextBlockStyle}"/>
                         <ProgressRing IsActive="{x:Bind ViewModel.HasRunningTasks, Mode=OneWay}" Width="16" Height="16" VerticalAlignment="Center"/>
                     </StackPanel>
                     <ListView x:Name="RunningTasksListView" ItemsSource="{x:Bind ViewModel.RunningTasksList, Mode=OneWay}" SelectionMode="None" IsItemClickEnabled="True" ItemClick="RunningTask_ItemClick" Padding="0">
@@ -196,13 +196,13 @@
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
-                    <TextBlock Text="No tasks currently running" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5"
+                    <TextBlock Text="当前没有正在运行的任务" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5"
                                Visibility="{x:Bind ViewModel.NoRunningTasksVisible, Mode=OneWay}"/>
                 </StackPanel>
 
                 <!-- Recently Failed Tasks -->
                 <StackPanel Spacing="6">
-                    <TextBlock Text="Recently Failed" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                    <TextBlock Text="最近失败任务" Style="{StaticResource SubtitleTextBlockStyle}"/>
                     <ListView x:Name="FailedTasksListView" ItemsSource="{x:Bind ViewModel.FailedTasksList, Mode=OneWay}" SelectionMode="None" IsItemClickEnabled="True" ItemClick="FailedTask_ItemClick" Padding="0">
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">
@@ -228,14 +228,14 @@
                                     <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="12,0,0,0">
                                         <TextBlock Text="{x:Bind LastRunTime}" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" HorizontalAlignment="Right"/>
                                         <TextBlock Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" HorizontalAlignment="Right">
-                                            <Run Text="Exit code: "/><Run Text="{x:Bind ExitCode}"/>
+                                            <Run Text="退出码："/><Run Text="{x:Bind ExitCode}"/>
                                         </TextBlock>
                                     </StackPanel>
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
-                    <TextBlock Text="No recent failures — all tasks healthy" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                    <TextBlock Text="近期无失败，任务状态良好" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.5" Foreground="{ThemeResource SystemFillColorSuccessBrush}"
                                Visibility="{x:Bind ViewModel.NoFailedTasksVisible, Mode=OneWay}"/>
                 </StackPanel>
 
@@ -247,7 +247,7 @@
 
                     <!-- Upcoming Schedule -->
                     <StackPanel Grid.Column="0" Spacing="6">
-                        <TextBlock Text="Upcoming Schedule" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                        <TextBlock Text="即将运行计划" Style="{StaticResource SubtitleTextBlockStyle}"/>
                         <ListView ItemsSource="{x:Bind ViewModel.UpcomingTasks, Mode=OneWay}" SelectionMode="None" Padding="0">
                             <ListView.ItemContainerStyle>
                                 <Style TargetType="ListViewItem">
@@ -281,7 +281,7 @@
 
                     <!-- Recent Activity Stream -->
                     <StackPanel Grid.Column="1" Spacing="6">
-                        <TextBlock Text="Activity Stream" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                        <TextBlock Text="活动流" Style="{StaticResource SubtitleTextBlockStyle}"/>
                         <ListView ItemsSource="{x:Bind ViewModel.RecentHistory, Mode=OneWay}" SelectionMode="None" Padding="0" IsItemClickEnabled="True" ItemClick="ActivityList_ItemClick">
                             <ListView.ItemContainerStyle>
                                 <Style TargetType="ListViewItem">
@@ -311,12 +311,12 @@
                 <StackPanel Spacing="10">
                     <!-- Header + Legend -->
                     <StackPanel Orientation="Horizontal" Spacing="16" VerticalAlignment="Center">
-                        <TextBlock Text="Run History — Last 7 Days" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                        <TextBlock Text="运行历史 — 最近 7 天" Style="{StaticResource SubtitleTextBlockStyle}"/>
                         <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                             <Rectangle Width="12" Height="12" Fill="{ThemeResource SystemFillColorSuccessBrush}" RadiusX="2" RadiusY="2"/>
-                            <TextBlock Text="Success" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7" VerticalAlignment="Center"/>
+                            <TextBlock Text="成功" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7" VerticalAlignment="Center"/>
                             <Rectangle Width="12" Height="12" Fill="{ThemeResource SystemFillColorCriticalBrush}" RadiusX="2" RadiusY="2" Margin="8,0,0,0"/>
-                            <TextBlock Text="Failure" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7" VerticalAlignment="Center"/>
+                            <TextBlock Text="失败" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7" VerticalAlignment="Center"/>
                         </StackPanel>
                     </StackPanel>
 

--- a/Dialogs/OnboardingDialog.xaml
+++ b/Dialogs/OnboardingDialog.xaml
@@ -54,11 +54,12 @@
                 Visibility="Collapsed">
             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                 <FontIcon Glyph="&#xE713;" FontSize="14" Opacity="0.7" VerticalAlignment="Center"/>
-                <TextBlock Text="You can replay this walkthrough anytime from Settings."
-                           FontSize="12"
-                           Opacity="0.7"
-                           TextWrapping="Wrap"
-                           VerticalAlignment="Center"/>
+                <TextBlock x:Uid="OnboardingHint"
+                           Text="You can replay this walkthrough anytime from Settings."
+                            FontSize="12"
+                            Opacity="0.7"
+                            TextWrapping="Wrap"
+                            VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 
@@ -72,11 +73,12 @@
             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                 <FontIcon Glyph="&#xE7BA;" FontSize="14" VerticalAlignment="Center"
                           Foreground="{ThemeResource SystemFillColorCautionBrush}"/>
-                <TextBlock Text="Some tasks are discovered via the Event Log and can thus not be edited.&#x0a;Run as admin if you want to edit them."
-                           FontSize="12"
-                           Opacity="0.85"
-                           TextWrapping="Wrap"
-                           VerticalAlignment="Center"/>
+                <TextBlock x:Uid="OnboardingWarn"
+                           Text="Some tasks are discovered via the Event Log and can thus not be edited.&#x0a;Run as admin if you want to edit them."
+                            FontSize="12"
+                            Opacity="0.85"
+                            TextWrapping="Wrap"
+                            VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 
@@ -97,14 +99,14 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <Button x:Name="BackButton"
+            <Button x:Name="BackButton" x:Uid="OnboardingBackButton"
                     Grid.Column="0"
                     Content="Back"
                     Click="BackButton_Click"
                     Visibility="Collapsed"
                     MinWidth="90"/>
 
-            <Button x:Name="NextButton"
+            <Button x:Name="NextButton" x:Uid="OnboardingNextButton"
                     Grid.Column="2"
                     Content="Next"
                     Click="NextButton_Click"

--- a/Dialogs/OnboardingDialog.xaml.cs
+++ b/Dialogs/OnboardingDialog.xaml.cs
@@ -8,6 +8,8 @@ namespace FluentTaskScheduler.Dialogs
 {
     public sealed partial class OnboardingDialog : ContentDialog
     {
+        private static string L(string key, string fallback) => Services.LocalizationService.GetString(key, fallback);
+
         // ── Step Definitions ─────────────────────────────────────────────────────
         private readonly struct Step
         {
@@ -23,56 +25,56 @@ namespace FluentTaskScheduler.Dialogs
             new Step
             {
                 Icon          = "\uE8A1",   // Calendar / Scheduler
-                Title         = "Welcome to FluentTaskScheduler",
-                Body          = "Manage Windows Task Scheduler with a modern, fluent interface — no XML, no fuss.",
+                Title         = L("Onboarding.Step1.Title", "Welcome to FluentTaskScheduler"),
+                Body          = L("Onboarding.Step1.Body", "Manage Windows Task Scheduler with a modern, fluent interface — no XML, no fuss."),
                 ShowHint      = false,
                 ShowAdminWarn = false
             },
             new Step
             {
                 Icon          = "\uE710",   // Add / Plus
-                Title         = "Create your first task",
-                Body          = "Hit + New Task to schedule any program, script, or command to run automatically — daily, on login, on an event, and more.",
+                Title         = L("Onboarding.Step2.Title", "Create your first task"),
+                Body          = L("Onboarding.Step2.Body", "Hit + New Task to schedule any program, script, or command to run automatically — daily, on login, on an event, and more."),
                 ShowHint      = false,
                 ShowAdminWarn = false
             },
             new Step
             {
                 Icon          = "\uE8B7",   // Folder
-                Title         = "Organise with folders",
-                Body          = "Group related tasks into folders using the sidebar, just like Windows Explorer. Your last folder is remembered across restarts.",
+                Title         = L("Onboarding.Step3.Title", "Organise with folders"),
+                Body          = L("Onboarding.Step3.Body", "Group related tasks into folders using the sidebar, just like Windows Explorer. Your last folder is remembered across restarts."),
                 ShowHint      = false,
                 ShowAdminWarn = false
             },
             new Step
             {
                 Icon          = "\uE9F9",   // Chart / History
-                Title         = "Track history & status",
-                Body          = "Click any task to see its run history, success and failure counts, and live running status — all in one place.",
+                Title         = L("Onboarding.Step4.Title", "Track history & status"),
+                Body          = L("Onboarding.Step4.Body", "Click any task to see its run history, success and failure counts, and live running status — all in one place."),
                 ShowHint      = false,
                 ShowAdminWarn = false
             },
             new Step
             {
                 Icon          = "\uE895",   // Sync / Updates
-                Title         = "Always up to date",
-                Body          = "FluentTaskScheduler checks for updates automatically every time it starts. You can also trigger a manual check at any time from Settings → About → Check for Updates.",
+                Title         = L("Onboarding.Step5.Title", "Always up to date"),
+                Body          = L("Onboarding.Step5.Body", "FluentTaskScheduler checks for updates automatically every time it starts. You can also trigger a manual check at any time from Settings → About → Check for Updates."),
                 ShowHint      = false,
                 ShowAdminWarn = false
             },
             new Step
             {
                 Icon          = "\uE773",   // Search
-                Title         = "Discover existing tasks",
-                Body          = "Use Task Discovery to scan the Windows Event Log and automatically import tasks created by other applications — no manual recreation needed.",
+                Title         = L("Onboarding.Step6.Title", "Discover existing tasks"),
+                Body          = L("Onboarding.Step6.Body", "Use Task Discovery to scan the Windows Event Log and automatically import tasks created by other applications — no manual recreation needed."),
                 ShowHint      = false,
                 ShowAdminWarn = true        // admin required for Event Log access
             },
             new Step
             {
                 Icon          = "\uE713",   // Settings
-                Title         = "Tune it to your liking",
-                Body          = "Head to Settings to enable Mica backdrop, minimise to tray, configure logging, run on startup, and more.",
+                Title         = L("Onboarding.Step7.Title", "Tune it to your liking"),
+                Body          = L("Onboarding.Step7.Body", "Head to Settings to enable Mica backdrop, minimise to tray, configure logging, run on startup, and more."),
                 ShowHint      = true,       // last slide gets the Settings hint
                 ShowAdminWarn = false
             }
@@ -125,7 +127,7 @@ namespace FluentTaskScheduler.Dialogs
 
             // Next / Get Started button
             bool isLast = _currentStep == Steps.Length - 1;
-            NextButton.Content = isLast ? "Get Started" : "Next";
+            NextButton.Content = isLast ? L("Dialog.GetStarted", "Get Started") : L("Dialog.Next", "Next");
 
             // Highlight active dot
             for (int i = 0; i < _dots.Length; i++)

--- a/Dialogs/WhatsNewDialog.xaml
+++ b/Dialogs/WhatsNewDialog.xaml
@@ -2,6 +2,7 @@
     x:Class="FluentTaskScheduler.Dialogs.WhatsNewDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Uid="WhatsNewDialog"
     CloseButtonText="Got it"
     DefaultButton="Close"
     CornerRadius="16">
@@ -68,7 +69,7 @@
                          Padding="0">
             <StackPanel Orientation="Horizontal" Spacing="6">
                 <FontIcon Glyph="&#xE8A7;" FontSize="13"/>
-                <TextBlock Text="View full release on GitHub" FontSize="13"/>
+                <TextBlock x:Uid="WhatsNewViewOnGitHub" Text="View full release on GitHub" FontSize="13"/>
             </StackPanel>
         </HyperlinkButton>
 

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -55,12 +55,12 @@
                 <StackPanel>
                     <StackPanel x:Name="FolderSection" Visibility="{x:Bind NavView.IsPaneOpen, Mode=OneWay}">
                         <Grid Margin="10,5,10,4">
-                            <TextBlock Text="Folders" 
+                            <TextBlock Text="文件夹" 
                                       FontWeight="SemiBold" 
                                       VerticalAlignment="Center"
                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
-                                <Button x:Name="FolderRefreshBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="ReloadFolders_Click" ToolTipService.ToolTip="Reload Folders">
+                                <Button x:Name="FolderRefreshBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="ReloadFolders_Click" ToolTipService.ToolTip="刷新文件夹">
                                     <Grid Width="14" Height="14">
                                         <Viewbox>
                                             <SymbolIcon x:Name="FolderRefreshIcon" Symbol="Refresh" />
@@ -68,7 +68,7 @@
                                         <ProgressRing x:Name="FolderRefreshRing" IsActive="False" Visibility="Collapsed" />
                                     </Grid>
                                 </Button>
-                                <Button x:Name="FolderCreateBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="CreateRootFolder_Click" ToolTipService.ToolTip="New Folder">
+                                <Button x:Name="FolderCreateBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="CreateRootFolder_Click" ToolTipService.ToolTip="新建文件夹">
                                     <Viewbox Width="14" Height="14">
                                         <SymbolIcon Symbol="Add" />
                                     </Viewbox>
@@ -128,7 +128,7 @@
                                                   VerticalAlignment="Center"
                                                   CanDrag="True"
                                                   DragStarting="FolderItem_DragStarting"
-                                                  ToolTipService.ToolTip="Drag to move folder"/>
+                                                   ToolTipService.ToolTip="拖动以移动文件夹"/>
                                     </Grid>
                                 </DataTemplate>
                             </TreeView.ItemTemplate>
@@ -139,9 +139,9 @@
 
             <NavigationView.MenuItems>
                 <NavigationViewItemSeparator />
-                <NavigationViewItem x:Name="NavDashboard" Tag="Dashboard" Icon="ViewAll" Content="Dashboard" />
-                <NavigationViewItem x:Name="NavScriptLibrary" Tag="ScriptLibrary" Icon="Library" Content="Script Library" />
-                <NavigationViewItem x:Name="NavAdd" Tag="Add" Icon="Add" Content="New Task" SelectsOnInvoked="False" />
+                <NavigationViewItem x:Name="NavDashboard" Tag="Dashboard" Icon="ViewAll" Content="仪表盘" />
+                <NavigationViewItem x:Name="NavScriptLibrary" Tag="ScriptLibrary" Icon="Library" Content="脚本库" />
+                <NavigationViewItem x:Name="NavAdd" Tag="Add" Icon="Add" Content="新建任务" SelectsOnInvoked="False" />
                 <NavigationViewItemSeparator />
             </NavigationView.MenuItems>
 
@@ -155,8 +155,8 @@
                 <NavigationViewItem x:Name="NavAllTasks" x:Uid="NavAllTasks" Tag="all" Icon="List" Content="All Tasks" IsSelected="True"/>
                 <NavigationViewItem x:Name="NavRunning" x:Uid="NavRunning" Tag="running" Icon="Play" Content="Running"/>
                 <NavigationViewItem x:Uid="NavEnabled" Content="Enabled" Icon="Accept" Tag="enabled" />
-                <NavigationViewItem x:Name="NavDisabled" Content="Disabled" Icon="Cancel" Tag="disabled" />
-                <NavigationViewItem x:Name="NavSettings" Tag="settings" Content="Settings"
+                <NavigationViewItem x:Name="NavDisabled" Content="已禁用" Icon="Cancel" Tag="disabled" />
+                <NavigationViewItem x:Name="NavSettings" Tag="settings" Content="设置"
                                    PointerEntered="Settings_PointerEntered"
                                    PointerExited="Settings_PointerExited">
                     <NavigationViewItem.Icon>
@@ -182,8 +182,8 @@
                 <!-- Admin Drag & Drop Warning -->
                 <InfoBar x:Name="AdminDragWarning"
                          Severity="Informational"
-                         Title="Drag &amp; Drop Restricted"
-                         Message="Windows does not support drag-and-drop operations when the app is running as Administrator."
+                         Title="拖拽受限"
+                         Message="当应用以管理员身份运行时，Windows 不支持拖放操作。"
                          IsClosable="True"
                          Margin="16,8,16,0"
                          Visibility="Collapsed"
@@ -203,43 +203,43 @@
                     </Grid.ColumnDefinitions>
                     
                     <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center" Margin="16,0,0,0">
-                        <TextBlock x:Name="BatchCountText" Text="0 selected" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="BatchCountText" Text="已选择 0 项" FontWeight="SemiBold" VerticalAlignment="Center"/>
                         <Rectangle Width="1" Height="24" Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
-                        <Button x:Name="BatchRunBtn" Click="BatchRun_Click" ToolTipService.ToolTip="Run Selected">
+                        <Button x:Name="BatchRunBtn" Click="BatchRun_Click" ToolTipService.ToolTip="运行所选">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Play"/>
-                                <TextBlock Text="Run"/>
+                                <TextBlock Text="运行"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BatchStopBtn" Click="BatchStop_Click" ToolTipService.ToolTip="Stop Selected">
+                        <Button x:Name="BatchStopBtn" Click="BatchStop_Click" ToolTipService.ToolTip="停止所选">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Stop"/>
-                                <TextBlock Text="Stop"/>
+                                <TextBlock Text="停止"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center" Margin="0,0,16,0">
-                       <Button x:Name="BatchEnableBtn" Click="BatchEnable_Click" ToolTipService.ToolTip="Enable Selected">
+                       <Button x:Name="BatchEnableBtn" Click="BatchEnable_Click" ToolTipService.ToolTip="启用所选">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Accept"/>
-                                <TextBlock Text="Enable"/>
+                                <TextBlock Text="启用"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BatchDisableBtn" Click="BatchDisable_Click" ToolTipService.ToolTip="Disable Selected">
+                        <Button x:Name="BatchDisableBtn" Click="BatchDisable_Click" ToolTipService.ToolTip="禁用所选">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Cancel"/>
-                                <TextBlock Text="Disable"/>
+                                <TextBlock Text="禁用"/>
                             </StackPanel>
                         </Button>
                         <Rectangle Width="1" Height="24" Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
-                        <Button x:Name="BatchDeleteBtn" Click="BatchDelete_Click" Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}" Foreground="White" ToolTipService.ToolTip="Delete Selected">
+                        <Button x:Name="BatchDeleteBtn" Click="BatchDelete_Click" Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}" Foreground="White" ToolTipService.ToolTip="删除所选">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Delete"/>
-                                <TextBlock Text="Delete"/>
+                                <TextBlock Text="删除"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BatchCancelBtn" Click="BatchCancel_Click" Background="Transparent" BorderThickness="0" ToolTipService.ToolTip="Clear Selection">
+                        <Button x:Name="BatchCancelBtn" Click="BatchCancel_Click" Background="Transparent" BorderThickness="0" ToolTipService.ToolTip="清除选择">
                             <SymbolIcon Symbol="Cancel"/>
                         </Button>
                     </StackPanel>
@@ -249,9 +249,9 @@
 
                     <AutoSuggestBox x:Name="SearchBox" x:Uid="SearchBox" QueryIcon="Find" PlaceholderText="Search tasks..." Width="300" TextChanged="SearchBox_TextChanged"/>
                     <Button x:Uid="RefreshButton" Content="Refresh" Click="RefreshButton_Click" />
-                    <Button x:Name="ImportTaskButton" Content="Import Task" Click="ImportTask_Click" />
-                    <Button x:Name="SortButton" Content="Sort ↕" Click="SortButton_Click" />
-                    <Button x:Name="ShortcutsButton" Content="?" Width="38" ToolTipService.ToolTip="Keyboard Shortcuts (F1)" Click="ShortcutsButton_Click" />
+                    <Button x:Name="ImportTaskButton" Content="导入任务" Click="ImportTask_Click" />
+                    <Button x:Name="SortButton" Content="排序 ↕" Click="SortButton_Click" />
+                    <Button x:Name="ShortcutsButton" Content="?" Width="38" ToolTipService.ToolTip="快捷键 (F1)" Click="ShortcutsButton_Click" />
                 </StackPanel>
 
                 <ListView x:Name="TaskListView" 
@@ -350,8 +350,8 @@
 
         <!-- Keyboard Shortcuts Dialog -->
         <ContentDialog x:Name="ShortcutsDialog"
-                       Title="Keyboard Shortcuts"
-                       CloseButtonText="Close"
+                       Title="快捷键"
+                       CloseButtonText="关闭"
                        DefaultButton="Close">
             <StackPanel Spacing="8" MinWidth="340">
                 <Grid>
@@ -365,24 +365,24 @@
                     </Grid.RowDefinitions>
 
                     <!-- Headers -->
-                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Shortcut" Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Action"   Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="快捷键" Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="操作"   Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
 
                     <!-- Rows -->
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Ctrl + N"  Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="New Task"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="新建任务"/>
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Ctrl + E"  Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Edit Selected Task"/>
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="编辑所选任务"/>
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="Ctrl + R"  Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Run Selected Task"/>
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="运行所选任务"/>
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Delete"    Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="4" Grid.Column="1" Text="Delete Selected Task"/>
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="删除所选任务"/>
                     <TextBlock Grid.Row="5" Grid.Column="0" Text="F5"        Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="5" Grid.Column="1" Text="Refresh Task List"/>
+                    <TextBlock Grid.Row="5" Grid.Column="1" Text="刷新任务列表"/>
                     <TextBlock Grid.Row="6" Grid.Column="0" Text="Esc"       Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="6" Grid.Column="1" Text="Close Dialogs / Clear Selection"/>
+                    <TextBlock Grid.Row="6" Grid.Column="1" Text="关闭对话框 / 清除选择"/>
                     <TextBlock Grid.Row="7" Grid.Column="0" Text="F1"        Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="7" Grid.Column="1" Text="Show This Dialog"/>
+                    <TextBlock Grid.Row="7" Grid.Column="1" Text="显示此对话框"/>
                 </Grid>
             </StackPanel>
         </ContentDialog>
@@ -554,10 +554,10 @@
                 <StackPanel Spacing="16" Width="750" Margin="0,8,12,8">
                 <TextBlock x:Uid="DialogTitle" Text="Add or edit task" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0"/>
                 <InfoBar x:Name="EditTaskErrorBar" IsOpen="False" Severity="Error" Margin="0,0,0,8" />
-                <TextBox x:Name="EditTaskName" x:Uid="TaskNameHeader" PlaceholderText="Enter task name">
+                <TextBox x:Name="EditTaskName" x:Uid="TaskNameHeader" PlaceholderText="输入任务名称">
                     <TextBox.Header>
                         <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="Task Name" VerticalAlignment="Center"/>
+                            <TextBlock Text="任务名称" VerticalAlignment="Center"/>
                             <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                       ToolTipService.ToolTip="The unique identifier for this task. It must be distinct within its folder in Windows Task Scheduler."/>
                         </StackPanel>
@@ -566,7 +566,7 @@
                 <TextBox x:Name="EditTaskDescription" x:Uid="DescriptionHeader" AcceptsReturn="True" Height="80">
                     <TextBox.Header>
                         <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="Description" VerticalAlignment="Center"/>
+                            <TextBlock Text="描述" VerticalAlignment="Center"/>
                             <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                       ToolTipService.ToolTip="A human-readable note that explains what this task does. Visible in Task Scheduler and the details panel."/>
                         </StackPanel>
@@ -575,7 +575,7 @@
                 <TextBox x:Name="EditTaskAuthor" x:Uid="AuthorHeader">
                     <TextBox.Header>
                         <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="Author" VerticalAlignment="Center"/>
+                            <TextBlock Text="作者" VerticalAlignment="Center"/>
                             <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                       ToolTipService.ToolTip="The person or system that owns this task. Stored in the task XML; not enforced by Windows."/>
                         </StackPanel>
@@ -587,7 +587,7 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <AutoSuggestBox x:Name="EditTaskCategory" PlaceholderText="e.g. Work" 
+                    <AutoSuggestBox x:Name="EditTaskCategory" PlaceholderText="例如：工作" 
                                    ItemsSource="{x:Bind ViewModel.SavedCategories}"
                                    QueryIcon="Find" 
                                    GotFocus="EditTaskCategory_GotFocus"
@@ -596,13 +596,13 @@
                                    SuggestionChosen="EditTaskCategory_SuggestionChosen">
                         <AutoSuggestBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="Category" VerticalAlignment="Center"/>
+                                <TextBlock Text="分类" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                           ToolTipService.ToolTip="Groups tasks together for filtering in the main list. Stored inside the task XML as the task's category label."/>
                             </StackPanel>
                         </AutoSuggestBox.Header>
                     </AutoSuggestBox>
-                    <AutoSuggestBox x:Name="EditTaskTags" Grid.Column="1" PlaceholderText="e.g. urgent, sync (comma separated)"
+                    <AutoSuggestBox x:Name="EditTaskTags" Grid.Column="1" PlaceholderText="例如：urgent, sync（逗号分隔）"
                                    QueryIcon="Find"
                                    GotFocus="EditTaskTags_GotFocus"
                                    Tapped="EditTaskTags_GotFocus"
@@ -610,7 +610,7 @@
                                    SuggestionChosen="EditTaskTags_SuggestionChosen">
                         <AutoSuggestBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="Tags" VerticalAlignment="Center"/>
+                                <TextBlock Text="标签" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                           ToolTipService.ToolTip="Custom comma-separated labels used for filtering inside this app. Tags are stored in the task Description field and are NOT a native Windows Task Scheduler feature."/>
                             </StackPanel>
@@ -800,35 +800,35 @@
 
                 <!-- Event Log Trigger -->
                 <StackPanel x:Name="PanelEvent" Visibility="Collapsed" Spacing="8" Margin="0,4,0,0">
-                    <TextBox x:Name="EditTaskEventLog" Header="Log" PlaceholderText="Application, System, Security, etc." Text="Application"/>
-                    <TextBox x:Name="EditTaskEventSource" Header="Source" PlaceholderText="e.g., VSS, Outlook (Optional)"/>
-                    <TextBox x:Name="EditTaskEventId" Header="Event ID" PlaceholderText="e.g., 1000 (Optional)" InputScope="Number"/>
+                    <TextBox x:Name="EditTaskEventLog" Header="日志" PlaceholderText="Application、System、Security 等" Text="Application"/>
+                    <TextBox x:Name="EditTaskEventSource" Header="来源" PlaceholderText="例如：VSS、Outlook（可选）"/>
+                    <TextBox x:Name="EditTaskEventId" Header="事件 ID" PlaceholderText="例如：1000（可选）" InputScope="Number"/>
                 </StackPanel>
 
                 <!-- Idle Trigger -->
                 <StackPanel x:Name="PanelIdle" Visibility="Collapsed" Spacing="8" Margin="0,4,0,0">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="Wait for the computer to be idle for:" VerticalAlignment="Center"/>
-                        <TextBox x:Name="EditTaskIdleDuration" PlaceholderText="e.g., 10m" Width="100" Text="PT10M"/>
-                        <TextBlock Text="(e.g. 5m, 10m, 30m)" VerticalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7"/>
+                        <TextBlock Text="等待计算机空闲时长：" VerticalAlignment="Center"/>
+                        <TextBox x:Name="EditTaskIdleDuration" PlaceholderText="例如：10m" Width="100" Text="PT10M"/>
+                        <TextBlock Text="（例如：5m、10m、30m）" VerticalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7"/>
                     </StackPanel>
                 </StackPanel>
 
                 <!-- Session State Change Trigger -->
                 <StackPanel x:Name="PanelSessionState" Visibility="Collapsed" Spacing="8" Margin="0,4,0,0">
-                    <ComboBox x:Name="EditTaskSessionStateType" Header="Trigger on" SelectedIndex="0" SelectionChanged="EditTaskSessionStateType_SelectionChanged">
-                        <ComboBoxItem Content="Workstation Lock" Tag="Lock"/>
-                        <ComboBoxItem Content="Workstation Unlock" Tag="Unlock"/>
-                        <ComboBoxItem Content="Remote Desktop Connect" Tag="RemoteConnect"/>
-                        <ComboBoxItem Content="Remote Desktop Disconnect" Tag="RemoteDisconnect"/>
+                    <ComboBox x:Name="EditTaskSessionStateType" Header="触发时机" SelectedIndex="0" SelectionChanged="EditTaskSessionStateType_SelectionChanged">
+                        <ComboBoxItem Content="工作站锁定" Tag="Lock"/>
+                        <ComboBoxItem Content="工作站解锁" Tag="Unlock"/>
+                        <ComboBoxItem Content="远程桌面连接" Tag="RemoteConnect"/>
+                        <ComboBoxItem Content="远程桌面断开" Tag="RemoteDisconnect"/>
                     </ComboBox>
                 </StackPanel>
 
                 <StackPanel Spacing="8" Margin="0,12,0,0">
                      <StackPanel Orientation="Horizontal" Spacing="4">
-                         <CheckBox x:Name="EditTaskExpires" Content="Expire task on:" Click="EditTaskExpires_Click"/>
+                         <CheckBox x:Name="EditTaskExpires" Content="到期时间：" Click="EditTaskExpires_Click"/>
                          <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                   ToolTipService.ToolTip="After this date and time the trigger will stop firing. The task itself remains; only the trigger is deactivated."/>
+                                   ToolTipService.ToolTip="超过该日期时间后将不再触发，任务本身仍保留，仅触发器被停用。"/>
                      </StackPanel>
                      <StackPanel Spacing="8" Margin="28,0,0,0">
                          <DatePicker x:Name="EditTaskExpirationDate" HorizontalAlignment="Left"/>
@@ -851,7 +851,7 @@
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock Text="Run:" FontWeight="SemiBold"/>
+                                     <TextBlock Text="运行：" FontWeight="SemiBold"/>
                                     <TextBlock Text="{Binding Command}" TextTrimming="CharacterEllipsis"/>
                                 </StackPanel>
                             </DataTemplate>
@@ -859,18 +859,18 @@
                     </ListView>
                     
                     <StackPanel Grid.Column="1" Spacing="4">
-                        <Button x:Name="BtnAddAction" Content="+" Width="32" ToolTipService.ToolTip="Add Action">
+                        <Button x:Name="BtnAddAction" Content="+" Width="32" ToolTipService.ToolTip="添加操作">
                             <Button.Flyout>
                                 <MenuFlyout>
-                                    <MenuFlyoutItem Text="Run Program" Click="BtnAddAction_Click" />
-                                    <MenuFlyoutItem Text="Send Email" Click="AddAction_SendEmail_Click" />
-                                    <MenuFlyoutItem Text="Show Notification" Click="AddAction_ShowNotification_Click" />
+                                    <MenuFlyoutItem Text="运行程序" Click="BtnAddAction_Click" />
+                                    <MenuFlyoutItem Text="发送邮件" Click="AddAction_SendEmail_Click" />
+                                    <MenuFlyoutItem Text="显示通知" Click="AddAction_ShowNotification_Click" />
                                 </MenuFlyout>
                             </Button.Flyout>
                         </Button>
-                        <Button x:Name="BtnRemoveAction" Content="-" Width="32" Click="BtnRemoveAction_Click" ToolTipService.ToolTip="Remove Action"/>
-                        <Button x:Name="BtnMoveActionUp" Content="^" Width="32" Click="BtnMoveActionUp_Click" ToolTipService.ToolTip="Move Up" FontSize="12"/>
-                        <Button x:Name="BtnMoveActionDown" Content="v" Width="32" Click="BtnMoveActionDown_Click" ToolTipService.ToolTip="Move Down" FontSize="11"/>
+                        <Button x:Name="BtnRemoveAction" Content="-" Width="32" Click="BtnRemoveAction_Click" ToolTipService.ToolTip="移除操作"/>
+                        <Button x:Name="BtnMoveActionUp" Content="^" Width="32" Click="BtnMoveActionUp_Click" ToolTipService.ToolTip="上移" FontSize="12"/>
+                        <Button x:Name="BtnMoveActionDown" Content="v" Width="32" Click="BtnMoveActionDown_Click" ToolTipService.ToolTip="下移" FontSize="11"/>
                     </StackPanel>
                 </Grid>
 
@@ -883,9 +883,9 @@
                         <TextBox x:Name="EditTaskActionCommand" x:Uid="ProgramScriptHeader" PlaceholderText="e.g., notepad.exe or C:\Scripts\myscript.ps1" Grid.Column="0" TextChanged="EditTaskActionCommand_TextChanged">
                             <TextBox.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <TextBlock Text="Program / Script" VerticalAlignment="Center"/>
+                                    <TextBlock Text="程序 / 脚本" VerticalAlignment="Center"/>
                                     <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                              ToolTipService.ToolTip="The full path or name of the executable, script, or document to launch. Use 'powershell.exe' with arguments for PowerShell scripts."/>
+                                              ToolTipService.ToolTip="可执行文件、脚本或文档的完整路径/名称。PowerShell 脚本请使用 powershell.exe 并配合参数。"/>
                                 </StackPanel>
                             </TextBox.Header>
                         </TextBox>
@@ -894,64 +894,64 @@
                     <TextBox x:Name="EditTaskArguments" x:Uid="ArgumentsHeader" PlaceholderText="e.g., /c echo hello or -File script.ps1" TextChanged="EditTaskArguments_TextChanged" Margin="0,8,0,0">
                         <TextBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="Arguments (optional)" VerticalAlignment="Center"/>
+                                <TextBlock Text="参数（可选）" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="Command-line parameters passed directly to the program. For PowerShell: -ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;"/>
+                                          ToolTipService.ToolTip="传递给程序的命令行参数。PowerShell 示例：-ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;"/>
                             </StackPanel>
                         </TextBox.Header>
                     </TextBox>
                     <TextBox x:Name="EditTaskWorkingDirectory" x:Uid="WorkingDirectoryHeader" PlaceholderText="e.g., C:\Scripts" TextChanged="EditTaskWorkingDirectory_TextChanged" Margin="0,8,0,0">
                         <TextBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="Run in (optional)" VerticalAlignment="Center"/>
+                                <TextBlock Text="运行目录（可选）" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="Sets the working directory (current folder) for the process. Relative paths in the program or script will resolve relative to this folder."/>
+                                          ToolTipService.ToolTip="设置进程工作目录（当前文件夹）。程序或脚本中的相对路径将相对此目录解析。"/>
                             </StackPanel>
                         </TextBox.Header>
                     </TextBox>
-                    <TextBlock Text="Tip: For PowerShell scripts, use 'powershell.exe' as Program and '-ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;' as Arguments" 
+                    <TextBlock Text="提示：PowerShell 脚本请将“程序”设为 powershell.exe，并将“参数”设为 -ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;" 
                                Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7" TextWrapping="Wrap" Margin="0,4,0,0"/>
                 </StackPanel>
                 
                 <!-- Repetition Section -->
                 <Rectangle Height="2" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" Margin="0,12,0,4"/>
-                <TextBlock Text="Repetition" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,4"/>
+                <TextBlock Text="重复" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,4"/>
                 <StackPanel Spacing="12">
                     <ComboBox x:Name="EditTaskRepetitionInterval" SelectedIndex="0" SelectionChanged="EditTaskRepetitionInterval_SelectionChanged">
                         <ComboBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="Repeat task every" VerticalAlignment="Center"/>
+                                <TextBlock Text="重复间隔" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="After the task starts, re-trigger it at this interval until the 'For a duration of' limit is reached. Useful for tasks that must run repeatedly within a window."/>
+                                          ToolTipService.ToolTip="任务启动后按该间隔重复触发，直到达到“持续时长”限制。适用于时间窗口内重复执行的任务。"/>
                             </StackPanel>
                         </ComboBox.Header>
-                        <ComboBoxItem Content="(No repetition)" Tag=""/>
-                        <ComboBoxItem Content="5 minutes" Tag="PT5M"/>
-                        <ComboBoxItem Content="10 minutes" Tag="PT10M"/>
-                        <ComboBoxItem Content="15 minutes" Tag="PT15M"/>
-                        <ComboBoxItem Content="30 minutes" Tag="PT30M"/>
-                        <ComboBoxItem Content="1 hour" Tag="PT1H"/>
-                        <ComboBoxItem Content="2 hours" Tag="PT2H"/>
-                        <ComboBoxItem Content="4 hours" Tag="PT4H"/>
-                        <ComboBoxItem Content="6 hours" Tag="PT6H"/>
-                        <ComboBoxItem Content="12 hours" Tag="PT12H"/>
+                        <ComboBoxItem Content="（不重复）" Tag=""/>
+                        <ComboBoxItem Content="5 分钟" Tag="PT5M"/>
+                        <ComboBoxItem Content="10 分钟" Tag="PT10M"/>
+                        <ComboBoxItem Content="15 分钟" Tag="PT15M"/>
+                        <ComboBoxItem Content="30 分钟" Tag="PT30M"/>
+                        <ComboBoxItem Content="1 小时" Tag="PT1H"/>
+                        <ComboBoxItem Content="2 小时" Tag="PT2H"/>
+                        <ComboBoxItem Content="4 小时" Tag="PT4H"/>
+                        <ComboBoxItem Content="6 小时" Tag="PT6H"/>
+                        <ComboBoxItem Content="12 小时" Tag="PT12H"/>
                     </ComboBox>
                     <ComboBox x:Name="EditTaskRepetitionDuration" x:Uid="RepetitionDurationHeader" SelectedIndex="0" SelectionChanged="EditTaskRepetitionDuration_SelectionChanged">
                         <ComboBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="For a duration of" VerticalAlignment="Center"/>
+                                <TextBlock Text="持续时长" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="How long the repetition continues. 'Indefinitely' means the task keeps repeating until the trigger itself expires. A finite duration caps the total repetition window."/>
+                                          ToolTipService.ToolTip="重复持续时间。“无限期”表示一直重复，直到触发器过期。有限时长会限制总重复窗口。"/>
                             </StackPanel>
                         </ComboBox.Header>
-                        <ComboBoxItem Content="Indefinitely" Tag=""/>
-                        <ComboBoxItem Content="1 hour" Tag="PT1H"/>
-                        <ComboBoxItem Content="2 hours" Tag="PT2H"/>
-                        <ComboBoxItem Content="4 hours" Tag="PT4H"/>
-                        <ComboBoxItem Content="6 hours" Tag="PT6H"/>
-                        <ComboBoxItem Content="12 hours" Tag="PT12H"/>
-                        <ComboBoxItem Content="24 hours" Tag="PT24H"/>
-                        <ComboBoxItem Content="1 day" Tag="P1D"/>
+                        <ComboBoxItem Content="无限期" Tag=""/>
+                        <ComboBoxItem Content="1 小时" Tag="PT1H"/>
+                        <ComboBoxItem Content="2 小时" Tag="PT2H"/>
+                        <ComboBoxItem Content="4 小时" Tag="PT4H"/>
+                        <ComboBoxItem Content="6 小时" Tag="PT6H"/>
+                        <ComboBoxItem Content="12 小时" Tag="PT12H"/>
+                        <ComboBoxItem Content="24 小时" Tag="PT24H"/>
+                        <ComboBoxItem Content="1 天" Tag="P1D"/>
                     </ComboBox>
                 </StackPanel>
                 

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -55,12 +55,12 @@
                 <StackPanel>
                     <StackPanel x:Name="FolderSection" Visibility="{x:Bind NavView.IsPaneOpen, Mode=OneWay}">
                         <Grid Margin="10,5,10,4">
-                            <TextBlock Text="文件夹" 
+                            <TextBlock Text="Folders" 
                                       FontWeight="SemiBold" 
                                       VerticalAlignment="Center"
                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
-                                <Button x:Name="FolderRefreshBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="ReloadFolders_Click" ToolTipService.ToolTip="刷新文件夹">
+                                <Button x:Name="FolderRefreshBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="ReloadFolders_Click" ToolTipService.ToolTip="Reload Folders">
                                     <Grid Width="14" Height="14">
                                         <Viewbox>
                                             <SymbolIcon x:Name="FolderRefreshIcon" Symbol="Refresh" />
@@ -68,7 +68,7 @@
                                         <ProgressRing x:Name="FolderRefreshRing" IsActive="False" Visibility="Collapsed" />
                                     </Grid>
                                 </Button>
-                                <Button x:Name="FolderCreateBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="CreateRootFolder_Click" ToolTipService.ToolTip="新建文件夹">
+                                <Button x:Name="FolderCreateBtn" Padding="4" Background="Transparent" BorderThickness="0" Click="CreateRootFolder_Click" ToolTipService.ToolTip="New Folder">
                                     <Viewbox Width="14" Height="14">
                                         <SymbolIcon Symbol="Add" />
                                     </Viewbox>
@@ -128,7 +128,7 @@
                                                   VerticalAlignment="Center"
                                                   CanDrag="True"
                                                   DragStarting="FolderItem_DragStarting"
-                                                   ToolTipService.ToolTip="拖动以移动文件夹"/>
+                                                  ToolTipService.ToolTip="Drag to move folder"/>
                                     </Grid>
                                 </DataTemplate>
                             </TreeView.ItemTemplate>
@@ -139,9 +139,9 @@
 
             <NavigationView.MenuItems>
                 <NavigationViewItemSeparator />
-                <NavigationViewItem x:Name="NavDashboard" Tag="Dashboard" Icon="ViewAll" Content="仪表盘" />
-                <NavigationViewItem x:Name="NavScriptLibrary" Tag="ScriptLibrary" Icon="Library" Content="脚本库" />
-                <NavigationViewItem x:Name="NavAdd" Tag="Add" Icon="Add" Content="新建任务" SelectsOnInvoked="False" />
+                <NavigationViewItem x:Name="NavDashboard" Tag="Dashboard" Icon="ViewAll" Content="Dashboard" />
+                <NavigationViewItem x:Name="NavScriptLibrary" Tag="ScriptLibrary" Icon="Library" Content="Script Library" />
+                <NavigationViewItem x:Name="NavAdd" Tag="Add" Icon="Add" Content="New Task" SelectsOnInvoked="False" />
                 <NavigationViewItemSeparator />
             </NavigationView.MenuItems>
 
@@ -154,9 +154,9 @@
             <NavigationView.FooterMenuItems>
                 <NavigationViewItem x:Name="NavAllTasks" x:Uid="NavAllTasks" Tag="all" Icon="List" Content="All Tasks" IsSelected="True"/>
                 <NavigationViewItem x:Name="NavRunning" x:Uid="NavRunning" Tag="running" Icon="Play" Content="Running"/>
-                <NavigationViewItem x:Uid="NavEnabled" Content="Enabled" Icon="Accept" Tag="enabled" />
-                <NavigationViewItem x:Name="NavDisabled" Content="已禁用" Icon="Cancel" Tag="disabled" />
-                <NavigationViewItem x:Name="NavSettings" Tag="settings" Content="设置"
+                <NavigationViewItem x:Name="NavEnabled" x:Uid="NavEnabled" Content="Enabled" Icon="Accept" Tag="enabled" />
+                <NavigationViewItem x:Name="NavDisabled" Content="Disabled" Icon="Cancel" Tag="disabled" />
+                <NavigationViewItem x:Name="NavSettings" Tag="settings" Content="Settings"
                                    PointerEntered="Settings_PointerEntered"
                                    PointerExited="Settings_PointerExited">
                     <NavigationViewItem.Icon>
@@ -182,8 +182,8 @@
                 <!-- Admin Drag & Drop Warning -->
                 <InfoBar x:Name="AdminDragWarning"
                          Severity="Informational"
-                         Title="拖拽受限"
-                         Message="当应用以管理员身份运行时，Windows 不支持拖放操作。"
+                         Title="Drag &amp; Drop Restricted"
+                         Message="Windows does not support drag-and-drop operations when the app is running as Administrator."
                          IsClosable="True"
                          Margin="16,8,16,0"
                          Visibility="Collapsed"
@@ -203,43 +203,43 @@
                     </Grid.ColumnDefinitions>
                     
                     <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center" Margin="16,0,0,0">
-                        <TextBlock x:Name="BatchCountText" Text="已选择 0 项" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="BatchCountText" Text="0 selected" FontWeight="SemiBold" VerticalAlignment="Center"/>
                         <Rectangle Width="1" Height="24" Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
-                        <Button x:Name="BatchRunBtn" Click="BatchRun_Click" ToolTipService.ToolTip="运行所选">
+                        <Button x:Name="BatchRunBtn" Click="BatchRun_Click" ToolTipService.ToolTip="Run Selected">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Play"/>
-                                <TextBlock Text="运行"/>
+                                <TextBlock Text="Run"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BatchStopBtn" Click="BatchStop_Click" ToolTipService.ToolTip="停止所选">
+                        <Button x:Name="BatchStopBtn" Click="BatchStop_Click" ToolTipService.ToolTip="Stop Selected">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Stop"/>
-                                <TextBlock Text="停止"/>
+                                <TextBlock Text="Stop"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center" Margin="0,0,16,0">
-                       <Button x:Name="BatchEnableBtn" Click="BatchEnable_Click" ToolTipService.ToolTip="启用所选">
+                       <Button x:Name="BatchEnableBtn" Click="BatchEnable_Click" ToolTipService.ToolTip="Enable Selected">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Accept"/>
-                                <TextBlock Text="启用"/>
+                                <TextBlock Text="Enable"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BatchDisableBtn" Click="BatchDisable_Click" ToolTipService.ToolTip="禁用所选">
+                        <Button x:Name="BatchDisableBtn" Click="BatchDisable_Click" ToolTipService.ToolTip="Disable Selected">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Cancel"/>
-                                <TextBlock Text="禁用"/>
+                                <TextBlock Text="Disable"/>
                             </StackPanel>
                         </Button>
                         <Rectangle Width="1" Height="24" Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
-                        <Button x:Name="BatchDeleteBtn" Click="BatchDelete_Click" Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}" Foreground="White" ToolTipService.ToolTip="删除所选">
+                        <Button x:Name="BatchDeleteBtn" Click="BatchDelete_Click" Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}" Foreground="White" ToolTipService.ToolTip="Delete Selected">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <SymbolIcon Symbol="Delete"/>
-                                <TextBlock Text="删除"/>
+                                <TextBlock Text="Delete"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="BatchCancelBtn" Click="BatchCancel_Click" Background="Transparent" BorderThickness="0" ToolTipService.ToolTip="清除选择">
+                        <Button x:Name="BatchCancelBtn" Click="BatchCancel_Click" Background="Transparent" BorderThickness="0" ToolTipService.ToolTip="Clear Selection">
                             <SymbolIcon Symbol="Cancel"/>
                         </Button>
                     </StackPanel>
@@ -248,10 +248,10 @@
                 <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Margin="16,24,0,12" Spacing="8">
 
                     <AutoSuggestBox x:Name="SearchBox" x:Uid="SearchBox" QueryIcon="Find" PlaceholderText="Search tasks..." Width="300" TextChanged="SearchBox_TextChanged"/>
-                    <Button x:Uid="RefreshButton" Content="Refresh" Click="RefreshButton_Click" />
-                    <Button x:Name="ImportTaskButton" Content="导入任务" Click="ImportTask_Click" />
-                    <Button x:Name="SortButton" Content="排序 ↕" Click="SortButton_Click" />
-                    <Button x:Name="ShortcutsButton" Content="?" Width="38" ToolTipService.ToolTip="快捷键 (F1)" Click="ShortcutsButton_Click" />
+                    <Button x:Name="RefreshButton" x:Uid="RefreshButton" Content="Refresh" Click="RefreshButton_Click" />
+                    <Button x:Name="ImportTaskButton" Content="Import Task" Click="ImportTask_Click" />
+                    <Button x:Name="SortButton" Content="Sort ↕" Click="SortButton_Click" />
+                    <Button x:Name="ShortcutsButton" Content="?" Width="38" ToolTipService.ToolTip="Keyboard Shortcuts (F1)" Click="ShortcutsButton_Click" />
                 </StackPanel>
 
                 <ListView x:Name="TaskListView" 
@@ -350,8 +350,8 @@
 
         <!-- Keyboard Shortcuts Dialog -->
         <ContentDialog x:Name="ShortcutsDialog"
-                       Title="快捷键"
-                       CloseButtonText="关闭"
+                       Title="Keyboard Shortcuts"
+                       CloseButtonText="Close"
                        DefaultButton="Close">
             <StackPanel Spacing="8" MinWidth="340">
                 <Grid>
@@ -365,24 +365,24 @@
                     </Grid.RowDefinitions>
 
                     <!-- Headers -->
-                    <TextBlock Grid.Row="0" Grid.Column="0" Text="快捷键" Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="操作"   Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Shortcut" Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Action"   Style="{StaticResource CaptionTextBlockStyle}" FontWeight="SemiBold" Opacity="0.6" Margin="0,0,0,6"/>
 
                     <!-- Rows -->
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Ctrl + N"  Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="新建任务"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="New Task"/>
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Ctrl + E"  Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="2" Grid.Column="1" Text="编辑所选任务"/>
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Edit Selected Task"/>
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="Ctrl + R"  Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="3" Grid.Column="1" Text="运行所选任务"/>
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Run Selected Task"/>
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Delete"    Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="4" Grid.Column="1" Text="删除所选任务"/>
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="Delete Selected Task"/>
                     <TextBlock Grid.Row="5" Grid.Column="0" Text="F5"        Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="5" Grid.Column="1" Text="刷新任务列表"/>
+                    <TextBlock Grid.Row="5" Grid.Column="1" Text="Refresh Task List"/>
                     <TextBlock Grid.Row="6" Grid.Column="0" Text="Esc"       Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="6" Grid.Column="1" Text="关闭对话框 / 清除选择"/>
+                    <TextBlock Grid.Row="6" Grid.Column="1" Text="Close Dialogs / Clear Selection"/>
                     <TextBlock Grid.Row="7" Grid.Column="0" Text="F1"        Style="{StaticResource BodyTextBlockStyle}" FontFamily="Consolas"/>
-                    <TextBlock Grid.Row="7" Grid.Column="1" Text="显示此对话框"/>
+                    <TextBlock Grid.Row="7" Grid.Column="1" Text="Show This Dialog"/>
                 </Grid>
             </StackPanel>
         </ContentDialog>
@@ -554,10 +554,10 @@
                 <StackPanel Spacing="16" Width="750" Margin="0,8,12,8">
                 <TextBlock x:Uid="DialogTitle" Text="Add or edit task" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,0"/>
                 <InfoBar x:Name="EditTaskErrorBar" IsOpen="False" Severity="Error" Margin="0,0,0,8" />
-                <TextBox x:Name="EditTaskName" x:Uid="TaskNameHeader" PlaceholderText="输入任务名称">
+                <TextBox x:Name="EditTaskName" x:Uid="TaskNameHeader" PlaceholderText="Enter task name">
                     <TextBox.Header>
                         <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="任务名称" VerticalAlignment="Center"/>
+                            <TextBlock Text="Task Name" VerticalAlignment="Center"/>
                             <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                       ToolTipService.ToolTip="The unique identifier for this task. It must be distinct within its folder in Windows Task Scheduler."/>
                         </StackPanel>
@@ -566,7 +566,7 @@
                 <TextBox x:Name="EditTaskDescription" x:Uid="DescriptionHeader" AcceptsReturn="True" Height="80">
                     <TextBox.Header>
                         <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="描述" VerticalAlignment="Center"/>
+                            <TextBlock Text="Description" VerticalAlignment="Center"/>
                             <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                       ToolTipService.ToolTip="A human-readable note that explains what this task does. Visible in Task Scheduler and the details panel."/>
                         </StackPanel>
@@ -575,7 +575,7 @@
                 <TextBox x:Name="EditTaskAuthor" x:Uid="AuthorHeader">
                     <TextBox.Header>
                         <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="作者" VerticalAlignment="Center"/>
+                            <TextBlock Text="Author" VerticalAlignment="Center"/>
                             <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                       ToolTipService.ToolTip="The person or system that owns this task. Stored in the task XML; not enforced by Windows."/>
                         </StackPanel>
@@ -587,7 +587,7 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <AutoSuggestBox x:Name="EditTaskCategory" PlaceholderText="例如：工作" 
+                    <AutoSuggestBox x:Name="EditTaskCategory" PlaceholderText="e.g. Work" 
                                    ItemsSource="{x:Bind ViewModel.SavedCategories}"
                                    QueryIcon="Find" 
                                    GotFocus="EditTaskCategory_GotFocus"
@@ -596,13 +596,13 @@
                                    SuggestionChosen="EditTaskCategory_SuggestionChosen">
                         <AutoSuggestBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="分类" VerticalAlignment="Center"/>
+                                <TextBlock Text="Category" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                           ToolTipService.ToolTip="Groups tasks together for filtering in the main list. Stored inside the task XML as the task's category label."/>
                             </StackPanel>
                         </AutoSuggestBox.Header>
                     </AutoSuggestBox>
-                    <AutoSuggestBox x:Name="EditTaskTags" Grid.Column="1" PlaceholderText="例如：urgent, sync（逗号分隔）"
+                    <AutoSuggestBox x:Name="EditTaskTags" Grid.Column="1" PlaceholderText="e.g. urgent, sync (comma separated)"
                                    QueryIcon="Find"
                                    GotFocus="EditTaskTags_GotFocus"
                                    Tapped="EditTaskTags_GotFocus"
@@ -610,7 +610,7 @@
                                    SuggestionChosen="EditTaskTags_SuggestionChosen">
                         <AutoSuggestBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="标签" VerticalAlignment="Center"/>
+                                <TextBlock Text="Tags" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
                                           ToolTipService.ToolTip="Custom comma-separated labels used for filtering inside this app. Tags are stored in the task Description field and are NOT a native Windows Task Scheduler feature."/>
                             </StackPanel>
@@ -800,35 +800,35 @@
 
                 <!-- Event Log Trigger -->
                 <StackPanel x:Name="PanelEvent" Visibility="Collapsed" Spacing="8" Margin="0,4,0,0">
-                    <TextBox x:Name="EditTaskEventLog" Header="日志" PlaceholderText="Application、System、Security 等" Text="Application"/>
-                    <TextBox x:Name="EditTaskEventSource" Header="来源" PlaceholderText="例如：VSS、Outlook（可选）"/>
-                    <TextBox x:Name="EditTaskEventId" Header="事件 ID" PlaceholderText="例如：1000（可选）" InputScope="Number"/>
+                    <TextBox x:Name="EditTaskEventLog" Header="Log" PlaceholderText="Application, System, Security, etc." Text="Application"/>
+                    <TextBox x:Name="EditTaskEventSource" Header="Source" PlaceholderText="e.g., VSS, Outlook (Optional)"/>
+                    <TextBox x:Name="EditTaskEventId" Header="Event ID" PlaceholderText="e.g., 1000 (Optional)" InputScope="Number"/>
                 </StackPanel>
 
                 <!-- Idle Trigger -->
                 <StackPanel x:Name="PanelIdle" Visibility="Collapsed" Spacing="8" Margin="0,4,0,0">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="等待计算机空闲时长：" VerticalAlignment="Center"/>
-                        <TextBox x:Name="EditTaskIdleDuration" PlaceholderText="例如：10m" Width="100" Text="PT10M"/>
-                        <TextBlock Text="（例如：5m、10m、30m）" VerticalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7"/>
+                        <TextBlock Text="Wait for the computer to be idle for:" VerticalAlignment="Center"/>
+                        <TextBox x:Name="EditTaskIdleDuration" PlaceholderText="e.g., 10m" Width="100" Text="PT10M"/>
+                        <TextBlock Text="(e.g. 5m, 10m, 30m)" VerticalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7"/>
                     </StackPanel>
                 </StackPanel>
 
                 <!-- Session State Change Trigger -->
                 <StackPanel x:Name="PanelSessionState" Visibility="Collapsed" Spacing="8" Margin="0,4,0,0">
-                    <ComboBox x:Name="EditTaskSessionStateType" Header="触发时机" SelectedIndex="0" SelectionChanged="EditTaskSessionStateType_SelectionChanged">
-                        <ComboBoxItem Content="工作站锁定" Tag="Lock"/>
-                        <ComboBoxItem Content="工作站解锁" Tag="Unlock"/>
-                        <ComboBoxItem Content="远程桌面连接" Tag="RemoteConnect"/>
-                        <ComboBoxItem Content="远程桌面断开" Tag="RemoteDisconnect"/>
+                    <ComboBox x:Name="EditTaskSessionStateType" Header="Trigger on" SelectedIndex="0" SelectionChanged="EditTaskSessionStateType_SelectionChanged">
+                        <ComboBoxItem Content="Workstation Lock" Tag="Lock"/>
+                        <ComboBoxItem Content="Workstation Unlock" Tag="Unlock"/>
+                        <ComboBoxItem Content="Remote Desktop Connect" Tag="RemoteConnect"/>
+                        <ComboBoxItem Content="Remote Desktop Disconnect" Tag="RemoteDisconnect"/>
                     </ComboBox>
                 </StackPanel>
 
                 <StackPanel Spacing="8" Margin="0,12,0,0">
                      <StackPanel Orientation="Horizontal" Spacing="4">
-                         <CheckBox x:Name="EditTaskExpires" Content="到期时间：" Click="EditTaskExpires_Click"/>
+                         <CheckBox x:Name="EditTaskExpires" Content="Expire task on:" Click="EditTaskExpires_Click"/>
                          <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                   ToolTipService.ToolTip="超过该日期时间后将不再触发，任务本身仍保留，仅触发器被停用。"/>
+                                   ToolTipService.ToolTip="After this date and time the trigger will stop firing. The task itself remains; only the trigger is deactivated."/>
                      </StackPanel>
                      <StackPanel Spacing="8" Margin="28,0,0,0">
                          <DatePicker x:Name="EditTaskExpirationDate" HorizontalAlignment="Left"/>
@@ -851,7 +851,7 @@
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                     <TextBlock Text="运行：" FontWeight="SemiBold"/>
+                                    <TextBlock Text="Run:" FontWeight="SemiBold"/>
                                     <TextBlock Text="{Binding Command}" TextTrimming="CharacterEllipsis"/>
                                 </StackPanel>
                             </DataTemplate>
@@ -859,18 +859,18 @@
                     </ListView>
                     
                     <StackPanel Grid.Column="1" Spacing="4">
-                        <Button x:Name="BtnAddAction" Content="+" Width="32" ToolTipService.ToolTip="添加操作">
+                        <Button x:Name="BtnAddAction" Content="+" Width="32" ToolTipService.ToolTip="Add Action">
                             <Button.Flyout>
                                 <MenuFlyout>
-                                    <MenuFlyoutItem Text="运行程序" Click="BtnAddAction_Click" />
-                                    <MenuFlyoutItem Text="发送邮件" Click="AddAction_SendEmail_Click" />
-                                    <MenuFlyoutItem Text="显示通知" Click="AddAction_ShowNotification_Click" />
+                                    <MenuFlyoutItem Text="Run Program" Click="BtnAddAction_Click" />
+                                    <MenuFlyoutItem Text="Send Email" Click="AddAction_SendEmail_Click" />
+                                    <MenuFlyoutItem Text="Show Notification" Click="AddAction_ShowNotification_Click" />
                                 </MenuFlyout>
                             </Button.Flyout>
                         </Button>
-                        <Button x:Name="BtnRemoveAction" Content="-" Width="32" Click="BtnRemoveAction_Click" ToolTipService.ToolTip="移除操作"/>
-                        <Button x:Name="BtnMoveActionUp" Content="^" Width="32" Click="BtnMoveActionUp_Click" ToolTipService.ToolTip="上移" FontSize="12"/>
-                        <Button x:Name="BtnMoveActionDown" Content="v" Width="32" Click="BtnMoveActionDown_Click" ToolTipService.ToolTip="下移" FontSize="11"/>
+                        <Button x:Name="BtnRemoveAction" Content="-" Width="32" Click="BtnRemoveAction_Click" ToolTipService.ToolTip="Remove Action"/>
+                        <Button x:Name="BtnMoveActionUp" Content="^" Width="32" Click="BtnMoveActionUp_Click" ToolTipService.ToolTip="Move Up" FontSize="12"/>
+                        <Button x:Name="BtnMoveActionDown" Content="v" Width="32" Click="BtnMoveActionDown_Click" ToolTipService.ToolTip="Move Down" FontSize="11"/>
                     </StackPanel>
                 </Grid>
 
@@ -883,9 +883,9 @@
                         <TextBox x:Name="EditTaskActionCommand" x:Uid="ProgramScriptHeader" PlaceholderText="e.g., notepad.exe or C:\Scripts\myscript.ps1" Grid.Column="0" TextChanged="EditTaskActionCommand_TextChanged">
                             <TextBox.Header>
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <TextBlock Text="程序 / 脚本" VerticalAlignment="Center"/>
+                                    <TextBlock Text="Program / Script" VerticalAlignment="Center"/>
                                     <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                              ToolTipService.ToolTip="可执行文件、脚本或文档的完整路径/名称。PowerShell 脚本请使用 powershell.exe 并配合参数。"/>
+                                              ToolTipService.ToolTip="The full path or name of the executable, script, or document to launch. Use 'powershell.exe' with arguments for PowerShell scripts."/>
                                 </StackPanel>
                             </TextBox.Header>
                         </TextBox>
@@ -894,64 +894,64 @@
                     <TextBox x:Name="EditTaskArguments" x:Uid="ArgumentsHeader" PlaceholderText="e.g., /c echo hello or -File script.ps1" TextChanged="EditTaskArguments_TextChanged" Margin="0,8,0,0">
                         <TextBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="参数（可选）" VerticalAlignment="Center"/>
+                                <TextBlock Text="Arguments (optional)" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="传递给程序的命令行参数。PowerShell 示例：-ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;"/>
+                                          ToolTipService.ToolTip="Command-line parameters passed directly to the program. For PowerShell: -ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;"/>
                             </StackPanel>
                         </TextBox.Header>
                     </TextBox>
                     <TextBox x:Name="EditTaskWorkingDirectory" x:Uid="WorkingDirectoryHeader" PlaceholderText="e.g., C:\Scripts" TextChanged="EditTaskWorkingDirectory_TextChanged" Margin="0,8,0,0">
                         <TextBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="运行目录（可选）" VerticalAlignment="Center"/>
+                                <TextBlock Text="Run in (optional)" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="设置进程工作目录（当前文件夹）。程序或脚本中的相对路径将相对此目录解析。"/>
+                                          ToolTipService.ToolTip="Sets the working directory (current folder) for the process. Relative paths in the program or script will resolve relative to this folder."/>
                             </StackPanel>
                         </TextBox.Header>
                     </TextBox>
-                    <TextBlock Text="提示：PowerShell 脚本请将“程序”设为 powershell.exe，并将“参数”设为 -ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;" 
+                    <TextBlock Text="Tip: For PowerShell scripts, use 'powershell.exe' as Program and '-ExecutionPolicy Bypass -File &quot;C:\path\to\script.ps1&quot;' as Arguments" 
                                Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7" TextWrapping="Wrap" Margin="0,4,0,0"/>
                 </StackPanel>
                 
                 <!-- Repetition Section -->
                 <Rectangle Height="2" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" Margin="0,12,0,4"/>
-                <TextBlock Text="重复" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,4"/>
+                <TextBlock Text="Repetition" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,8,0,4"/>
                 <StackPanel Spacing="12">
                     <ComboBox x:Name="EditTaskRepetitionInterval" SelectedIndex="0" SelectionChanged="EditTaskRepetitionInterval_SelectionChanged">
                         <ComboBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="重复间隔" VerticalAlignment="Center"/>
+                                <TextBlock Text="Repeat task every" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="任务启动后按该间隔重复触发，直到达到“持续时长”限制。适用于时间窗口内重复执行的任务。"/>
+                                          ToolTipService.ToolTip="After the task starts, re-trigger it at this interval until the 'For a duration of' limit is reached. Useful for tasks that must run repeatedly within a window."/>
                             </StackPanel>
                         </ComboBox.Header>
-                        <ComboBoxItem Content="（不重复）" Tag=""/>
-                        <ComboBoxItem Content="5 分钟" Tag="PT5M"/>
-                        <ComboBoxItem Content="10 分钟" Tag="PT10M"/>
-                        <ComboBoxItem Content="15 分钟" Tag="PT15M"/>
-                        <ComboBoxItem Content="30 分钟" Tag="PT30M"/>
-                        <ComboBoxItem Content="1 小时" Tag="PT1H"/>
-                        <ComboBoxItem Content="2 小时" Tag="PT2H"/>
-                        <ComboBoxItem Content="4 小时" Tag="PT4H"/>
-                        <ComboBoxItem Content="6 小时" Tag="PT6H"/>
-                        <ComboBoxItem Content="12 小时" Tag="PT12H"/>
+                        <ComboBoxItem Content="(No repetition)" Tag=""/>
+                        <ComboBoxItem Content="5 minutes" Tag="PT5M"/>
+                        <ComboBoxItem Content="10 minutes" Tag="PT10M"/>
+                        <ComboBoxItem Content="15 minutes" Tag="PT15M"/>
+                        <ComboBoxItem Content="30 minutes" Tag="PT30M"/>
+                        <ComboBoxItem Content="1 hour" Tag="PT1H"/>
+                        <ComboBoxItem Content="2 hours" Tag="PT2H"/>
+                        <ComboBoxItem Content="4 hours" Tag="PT4H"/>
+                        <ComboBoxItem Content="6 hours" Tag="PT6H"/>
+                        <ComboBoxItem Content="12 hours" Tag="PT12H"/>
                     </ComboBox>
                     <ComboBox x:Name="EditTaskRepetitionDuration" x:Uid="RepetitionDurationHeader" SelectedIndex="0" SelectionChanged="EditTaskRepetitionDuration_SelectionChanged">
                         <ComboBox.Header>
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="持续时长" VerticalAlignment="Center"/>
+                                <TextBlock Text="For a duration of" VerticalAlignment="Center"/>
                                 <FontIcon Glyph="&#xE946;" FontSize="12" VerticalAlignment="Center" Opacity="0.6" Tapped="InfoIcon_Tapped"
-                                          ToolTipService.ToolTip="重复持续时间。“无限期”表示一直重复，直到触发器过期。有限时长会限制总重复窗口。"/>
+                                          ToolTipService.ToolTip="How long the repetition continues. 'Indefinitely' means the task keeps repeating until the trigger itself expires. A finite duration caps the total repetition window."/>
                             </StackPanel>
                         </ComboBox.Header>
-                        <ComboBoxItem Content="无限期" Tag=""/>
-                        <ComboBoxItem Content="1 小时" Tag="PT1H"/>
-                        <ComboBoxItem Content="2 小时" Tag="PT2H"/>
-                        <ComboBoxItem Content="4 小时" Tag="PT4H"/>
-                        <ComboBoxItem Content="6 小时" Tag="PT6H"/>
-                        <ComboBoxItem Content="12 小时" Tag="PT12H"/>
-                        <ComboBoxItem Content="24 小时" Tag="PT24H"/>
-                        <ComboBoxItem Content="1 天" Tag="P1D"/>
+                        <ComboBoxItem Content="Indefinitely" Tag=""/>
+                        <ComboBoxItem Content="1 hour" Tag="PT1H"/>
+                        <ComboBoxItem Content="2 hours" Tag="PT2H"/>
+                        <ComboBoxItem Content="4 hours" Tag="PT4H"/>
+                        <ComboBoxItem Content="6 hours" Tag="PT6H"/>
+                        <ComboBoxItem Content="12 hours" Tag="PT12H"/>
+                        <ComboBoxItem Content="24 hours" Tag="PT24H"/>
+                        <ComboBoxItem Content="1 day" Tag="P1D"/>
                     </ComboBox>
                 </StackPanel>
                 

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -37,6 +37,7 @@ namespace FluentTaskScheduler
         // Current folder path for new task creation
         private string _currentFolderPath = "\\";
         private Dictionary<string, bool> _folderExpandedState = new();
+        private static string L(string key, string fallback) => LocalizationService.GetString(key, fallback);
 
         public static MainPage? Current { get; private set; }
 
@@ -619,9 +620,9 @@ namespace FluentTaskScheduler
              var dp = new DataPackage();
              dp.SetText(string.Join("\n", _fullHistory.Select(h => $"{h.Time}\t{h.Result}\t{h.Message}")));
              Clipboard.SetContent(dp);
-             CopyHistoryBtn.Content = "✅ Copied!";
+             CopyHistoryBtn.Content = L("Main.HistoryCopied", "✅ Copied!");
              await Task.Delay(2000);
-             CopyHistoryBtn.Content = "📋 Copy";
+             CopyHistoryBtn.Content = L("Main.HistoryCopy", "📋 Copy");
         }
         
         private void StatTotal_Tapped(object sender, TappedRoutedEventArgs e) { _historyStatusFilter = "Total"; UpdateHistoryList(); }
@@ -732,10 +733,10 @@ namespace FluentTaskScheduler
 
             var dialog = new ContentDialog 
             { 
-                Title = "Confirm Delete", 
-                Content = $"Are you sure you want to delete '{ViewModel.SelectedTask.Name}'?", 
-                PrimaryButtonText = "Delete", 
-                CloseButtonText = "Cancel", 
+                Title = L("Main.ConfirmDelete.Title", "Confirm Delete"), 
+                Content = string.Format(L("Main.ConfirmDelete.Content", "Are you sure you want to delete '{0}'?"), ViewModel.SelectedTask.Name), 
+                PrimaryButtonText = L("Dialog.Delete", "Delete"), 
+                CloseButtonText = L("Dialog.Cancel", "Cancel"), 
                 DefaultButton = ContentDialogButton.Close, 
                 XamlRoot = this.XamlRoot 
             };
@@ -812,15 +813,15 @@ namespace FluentTaskScheduler
                 };
 
                 var panel = new StackPanel();
-                panel.Children.Add(new TextBlock { Text = "Select the folder to import this task into:" });
+                panel.Children.Add(new TextBlock { Text = L("Main.ImportTask.SelectFolder", "Select the folder to import this task into:") });
                 panel.Children.Add(comboBox);
 
                 var dialog = new ContentDialog
                 {
-                    Title = "Import Task",
+                    Title = L("Main.ImportTask.Title", "Import Task"),
                     Content = panel,
-                    PrimaryButtonText = "Import",
-                    CloseButtonText = "Cancel",
+                    PrimaryButtonText = L("Dialog.Import", "Import"),
+                    CloseButtonText = L("Dialog.Cancel", "Cancel"),
                     DefaultButton = ContentDialogButton.Primary,
                     XamlRoot = this.XamlRoot
                 };
@@ -1137,7 +1138,7 @@ namespace FluentTaskScheduler
                 // Non-admin: disable dropdown and show explanation notice
                 EditTaskNetworkSelection.IsEnabled = false;
                 EditTaskNetworkSelection.Items.Clear();
-                EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = "Any network", Tag = "" });
+                EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = L("Main.AnyNetwork", "Any network"), Tag = "" });
                 EditTaskNetworkSelection.SelectedIndex = 0;
                 NetworkAdminNotice.IsOpen = true;
                 return;
@@ -1147,7 +1148,7 @@ namespace FluentTaskScheduler
             NetworkAdminNotice.IsOpen = false;
             EditTaskNetworkSelection.IsEnabled = true;
             EditTaskNetworkSelection.Items.Clear();
-            EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = "Any network", Tag = "" });
+            EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = L("Main.AnyNetwork", "Any network"), Tag = "" });
 
             try
             {
@@ -1344,12 +1345,12 @@ namespace FluentTaskScheduler
             }
         }
         private void BatchStop_Click(object sender, RoutedEventArgs e) => PerformBatchAction(t => { ViewModel.TaskService.StopTask(t.Path); t.State = "Ready"; });
-        private async void BatchEnable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (!t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, true); t.IsEnabled = true; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog($"The user account under which you are performing this action does not have permission to enable the following task(s):\n\n{string.Join("\n", denied)}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."); }
-        private async void BatchDisable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, false); t.IsEnabled = false; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog($"The user account under which you are performing this action does not have permission to disable the following task(s):\n\n{string.Join("\n", denied)}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."); }
+        private async void BatchEnable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (!t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, true); t.IsEnabled = true; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog(string.Format(L("Main.PermissionEnableDenied", "The user account under which you are performing this action does not have permission to enable the following task(s):\n\n{0}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."), string.Join("\n", denied))); }
+        private async void BatchDisable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, false); t.IsEnabled = false; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog(string.Format(L("Main.PermissionDisableDenied", "The user account under which you are performing this action does not have permission to disable the following task(s):\n\n{0}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."), string.Join("\n", denied))); }
         private async void BatchDelete_Click(object sender, RoutedEventArgs e) 
         { 
              var tasks = TaskListView.SelectedItems.Cast<ScheduledTaskModel>().ToList();
-             var dialog = new ContentDialog { Title = "Confirm Delete", Content = $"Delete {tasks.Count} tasks?", PrimaryButtonText = "Delete", CloseButtonText = "Cancel", DefaultButton = ContentDialogButton.Close, XamlRoot = this.XamlRoot };
+             var dialog = new ContentDialog { Title = L("Main.ConfirmDelete.Title", "Confirm Delete"), Content = string.Format(L("Main.BatchDelete.Content", "Delete {0} tasks?"), tasks.Count), PrimaryButtonText = L("Dialog.Delete", "Delete"), CloseButtonText = L("Dialog.Cancel", "Cancel"), DefaultButton = ContentDialogButton.Close, XamlRoot = this.XamlRoot };
              if (await dialog.ShowAsync() == ContentDialogResult.Primary)
              {
                  foreach(var t in tasks) try { ViewModel.TaskService.DeleteTask(t.Path); } catch {}
@@ -1478,7 +1479,7 @@ namespace FluentTaskScheduler
 
         private async void CreateFolder_Click(string parentPath)
         {
-            var dialog = new ContentDialog { Title="New Folder", Content=new TextBox{PlaceholderText="Name"}, PrimaryButtonText="Create", CloseButtonText="Cancel", DefaultButton=ContentDialogButton.Primary, XamlRoot=this.XamlRoot, RequestedTheme=Services.SettingsService.Theme };
+            var dialog = new ContentDialog { Title=L("Main.NewFolder.Title", "New Folder"), Content=new TextBox{PlaceholderText=L("Main.NewFolder.NamePlaceholder", "Name")}, PrimaryButtonText=L("Dialog.Create", "Create"), CloseButtonText=L("Dialog.Cancel", "Cancel"), DefaultButton=ContentDialogButton.Primary, XamlRoot=this.XamlRoot, RequestedTheme=Services.SettingsService.Theme };
             if (await dialog.ShowAsync() == ContentDialogResult.Primary && dialog.Content is TextBox tb && !string.IsNullOrWhiteSpace(tb.Text)) 
             { 
                 try 
@@ -1495,15 +1496,15 @@ namespace FluentTaskScheduler
 
         private async void RenameFolder_Click(string path, string oldName)
         {
-            var tb = new TextBox { Text = oldName, PlaceholderText = "New Name" };
+            var tb = new TextBox { Text = oldName, PlaceholderText = L("Main.RenameFolder.NamePlaceholder", "New Name") };
             tb.SelectAll();
             
             var dialog = new ContentDialog
             {
-                Title = "Rename Folder",
+                Title = L("Main.RenameFolder.Title", "Rename Folder"),
                 Content = tb,
-                PrimaryButtonText = "Rename",
-                CloseButtonText = "Cancel",
+                PrimaryButtonText = L("Dialog.Rename", "Rename"),
+                CloseButtonText = L("Dialog.Cancel", "Cancel"),
                 DefaultButton = ContentDialogButton.Primary,
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = Services.SettingsService.Theme
@@ -1532,7 +1533,7 @@ namespace FluentTaskScheduler
 
         private async void DeleteFolder_Click(string path)
         {
-            var dialog = new ContentDialog { Title="Delete Folder", Content=$"Delete '{path}' and ALL tasks in it?", PrimaryButtonText="Delete", CloseButtonText="Cancel", DefaultButton=ContentDialogButton.Close, XamlRoot=this.XamlRoot, RequestedTheme=Services.SettingsService.Theme };
+            var dialog = new ContentDialog { Title=L("Main.DeleteFolder.Title", "Delete Folder"), Content=string.Format(L("Main.DeleteFolder.Content", "Delete '{0}' and ALL tasks in it?"), path), PrimaryButtonText=L("Dialog.Delete", "Delete"), CloseButtonText=L("Dialog.Cancel", "Cancel"), DefaultButton=ContentDialogButton.Close, XamlRoot=this.XamlRoot, RequestedTheme=Services.SettingsService.Theme };
             if (await dialog.ShowAsync() == ContentDialogResult.Primary) 
             { 
                 try 
@@ -1856,7 +1857,7 @@ namespace FluentTaskScheduler
             LoadFolderStructure();
 
             if (errors.Count > 0)
-                await ShowErrorDialog("Some tasks could not be moved:\n\n" + string.Join("\n", errors));
+                await ShowErrorDialog(L("Main.MoveTasksPartialError", "Some tasks could not be moved:\n\n") + string.Join("\n", errors));
         }
 
         private async System.Threading.Tasks.Task MoveDraggedFolderAsync(string sourceFolderPath, string targetFolderPath)
@@ -1870,7 +1871,7 @@ namespace FluentTaskScheduler
                 LoadFolderStructure();
                 await ViewModel.LoadTasksAsync();
             }
-            catch (Exception ex) { await ShowErrorDialog($"Could not move folder: {ex.Message}"); }
+            catch (Exception ex) { await ShowErrorDialog(string.Format(L("Main.MoveFolderError", "Could not move folder: {0}"), ex.Message)); }
         }
 
 
@@ -1882,9 +1883,9 @@ namespace FluentTaskScheduler
             { 
                 var dialog = new ContentDialog 
                 { 
-                    Title = "Error", 
+                    Title = L("Main.Error.Title", "Error"), 
                     Content = message, 
-                    CloseButtonText = "OK", 
+                    CloseButtonText = L("Dialog.OK", "OK"), 
                     XamlRoot = this.XamlRoot, 
                     RequestedTheme = Services.SettingsService.Theme 
                 };

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -314,7 +314,7 @@ namespace FluentTaskScheduler
                 ViewModel.SetFilter(folder.Path);
                 
                 // Restore Task View
-                NavView.Header = "Scheduled Tasks";
+                NavView.Header = "计划任务";
                 TasksViewGrid.Visibility = Visibility.Visible;
                 ContentFrame.Visibility = Visibility.Collapsed;
                 
@@ -327,7 +327,7 @@ namespace FluentTaskScheduler
         {
             if (args.IsSettingsSelected || (args.SelectedItem is NavigationViewItem settingsItem && settingsItem.Tag?.ToString() == "settings")) 
             {
-                 NavView.Header = "Settings";
+                 NavView.Header = "设置";
                  ContentFrame.Visibility = Visibility.Visible;
                  TasksViewGrid.Visibility = Visibility.Collapsed;
                  ContentFrame.Navigate(typeof(SettingsPage));
@@ -338,7 +338,7 @@ namespace FluentTaskScheduler
 
                 if (tag == "Dashboard")
                 {
-                    NavView.Header = "Dashboard";
+                    NavView.Header = "仪表盘";
                     TasksViewGrid.Visibility = Visibility.Collapsed;
                     ContentFrame.Visibility = Visibility.Visible;
                     ContentFrame.Navigate(typeof(DashboardPage));
@@ -346,7 +346,7 @@ namespace FluentTaskScheduler
                 }
                 else if (tag == "ScriptLibrary")
                 {
-                    NavView.Header = "Script Library";
+                    NavView.Header = "脚本库";
                     TasksViewGrid.Visibility = Visibility.Collapsed;
                     ContentFrame.Visibility = Visibility.Visible;
                     ContentFrame.Navigate(typeof(ScriptLibraryPage), this);
@@ -355,7 +355,7 @@ namespace FluentTaskScheduler
                 else
                 {
                     // Standard Task Views (if any)
-                    NavView.Header = "Scheduled Tasks";
+                    NavView.Header = "计划任务";
                     TasksViewGrid.Visibility = Visibility.Visible;
                     ContentFrame.Visibility = Visibility.Collapsed;
                     FolderTreeView.SelectedItem = null;
@@ -389,7 +389,7 @@ namespace FluentTaskScheduler
         {
             // Switch to Tasks View
             NavView.SelectedItem = null; // Clear selection to indicate custom state or select "All Tasks"
-            NavView.Header = "Scheduled Tasks";
+            NavView.Header = "计划任务";
             TasksViewGrid.Visibility = Visibility.Visible;
             ContentFrame.Visibility = Visibility.Collapsed;
             FolderTreeView.SelectedItem = null;
@@ -453,7 +453,7 @@ namespace FluentTaskScheduler
             if (BatchActionBar != null)
             {
                 BatchActionBar.Visibility = count > 1 ? Visibility.Visible : Visibility.Collapsed;
-                if (BatchCountText != null) BatchCountText.Text = $"{count} selected";
+                if (BatchCountText != null) BatchCountText.Text = $"已选择 {count} 项";
                 UpdateBatchActionsState();
             }
             if (count == 1) ViewModel.SelectedTask = (ScheduledTaskModel)TaskListView.SelectedItem;
@@ -1396,12 +1396,12 @@ namespace FluentTaskScheduler
                 flyout.Items.Add(item);
             }
 
-            AddItem("Name",         "Name");
-            AddItem("Status",       "Status");
-            AddItem("Next Run",     "NextRun");
-            AddItem("Last Run",     "LastRun");
+            AddItem("名称",         "Name");
+            AddItem("状态",       "Status");
+            AddItem("下次运行",     "NextRun");
+            AddItem("上次运行",     "LastRun");
             flyout.Items.Add(new MenuFlyoutSeparator());
-            var clear = new MenuFlyoutItem { Text = "Clear Sort" };
+            var clear = new MenuFlyoutItem { Text = "清除排序" };
             clear.Click += (s, _) => { ViewModel.ClearSort(); UpdateSortButtonText(); };
             flyout.Items.Add(clear);
 
@@ -1412,8 +1412,8 @@ namespace FluentTaskScheduler
         {
             string arrow = ViewModel.SortAscending ? "â–²" : "â–¼";
             SortButton.Content = string.IsNullOrEmpty(ViewModel.SortColumn)
-                ? "Sort \u2195"
-                : $"Sort {arrow} {ViewModel.SortColumn}";
+                ? "排序 \u2195"
+                : $"排序 {arrow} {ViewModel.SortColumn}";
         }
 
         private async void ReloadFolders_Click(object sender, RoutedEventArgs e)

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -37,7 +37,6 @@ namespace FluentTaskScheduler
         // Current folder path for new task creation
         private string _currentFolderPath = "\\";
         private Dictionary<string, bool> _folderExpandedState = new();
-        private static string L(string key, string fallback) => LocalizationService.GetString(key, fallback);
 
         public static MainPage? Current { get; private set; }
 
@@ -46,6 +45,8 @@ namespace FluentTaskScheduler
             Current = this;
             this.InitializeComponent();
             this.Loaded += MainPage_Loaded;
+            this.Unloaded += MainPage_Unloaded;
+            LocalizationService.LanguageChanged += LocalizationService_LanguageChanged;
             
             _searchDebounceTimer = DispatcherQueue.CreateTimer();
             _searchDebounceTimer.Interval = TimeSpan.FromMilliseconds(300);
@@ -56,6 +57,80 @@ namespace FluentTaskScheduler
             };
             
             NavView.SelectedItem = NavView.FooterMenuItems[0];  // Select "All Tasks" 
+            ApplyLocalizedUi();
+        }
+
+        private void MainPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            LocalizationService.LanguageChanged -= LocalizationService_LanguageChanged;
+            if (ReferenceEquals(Current, this))
+            {
+                Current = null;
+            }
+        }
+
+        private void LocalizationService_LanguageChanged(object? sender, EventArgs e)
+        {
+            if (DispatcherQueue == null) return;
+            DispatcherQueue.TryEnqueue(ApplyLocalizedUi);
+        }
+
+        private static string L(string key, string fallback) => LocalizationService.GetString(key, fallback);
+
+        public void RefreshLocalizedUi() => ApplyLocalizedUi();
+
+        private void ApplyLocalizedUi()
+        {
+            NavDashboard.Content = L("Main.Nav.Dashboard", "Dashboard");
+            NavScriptLibrary.Content = L("Main.Nav.ScriptLibrary", "Script Library");
+            NavAdd.Content = L("Main.Nav.NewTask", "New Task");
+            NavAllTasks.Content = L("Main.Nav.AllTasks", "All Tasks");
+            NavRunning.Content = L("Main.Nav.Running", "Running");
+            NavEnabled.Content = L("Main.Nav.Enabled", "Enabled");
+            NavDisabled.Content = L("Main.Nav.Disabled", "Disabled");
+            NavSettings.Content = L("Main.Nav.Settings", "Settings");
+
+            RefreshButton.Content = L("Main.Toolbar.Refresh", "Refresh");
+            ImportTaskButton.Content = L("Main.Toolbar.ImportTask", "Import Task");
+            ShortcutsButton.Content = L("Main.Toolbar.ShortcutsButton", "?");
+            ToolTipService.SetToolTip(ShortcutsButton, L("Main.Toolbar.ShortcutsTooltip", "Keyboard Shortcuts (F1)"));
+            UpdateSortButtonText();
+
+            CopyHistoryBtn.Content = L("Main.History.Copy", "📋 Copy");
+            TaskHistoryDialog.Title = L("Main.HistoryDialog.Title", "Task History");
+            TaskHistoryDialog.CloseButtonText = L("Dialog.Common.Close", "Close");
+
+            ShortcutsDialog.Title = L("Main.ShortcutsDialog.Title", "Keyboard Shortcuts");
+            ShortcutsDialog.CloseButtonText = L("Dialog.Common.Close", "Close");
+
+            TaskDetailsDialog.CloseButtonText = L("Dialog.Common.Close", "Close");
+            RunTaskButton.Content = L("Main.Task.RunNow", "Run Now");
+            StopTaskButton.Content = L("Main.Task.Stop", "Stop");
+            EditTaskButton.Content = L("Main.Task.Edit", "Edit");
+            ExportTaskButton.Content = L("Main.Task.Export", "Export");
+            DeleteTaskButton.Content = L("Main.Task.Delete", "Delete");
+
+            TaskEditDialog.PrimaryButtonText = L("Dialog.Common.Save", "Save");
+            TaskEditDialog.CloseButtonText = L("Dialog.Common.Cancel", "Cancel");
+
+            AdminDragWarning.Title = L("Main.AdminDragWarning.Title", "Drag & Drop Restricted");
+            AdminDragWarning.Message = L("Main.AdminDragWarning.Message", "Windows does not support drag-and-drop operations when the app is running as Administrator.");
+
+            if (NavView.SelectedItem is NavigationViewItem selectedItem && selectedItem.Tag != null)
+            {
+                string tag = selectedItem.Tag.ToString() ?? string.Empty;
+                NavView.Header = tag switch
+                {
+                    "Dashboard" => L("Main.Header.Dashboard", "Dashboard"),
+                    "ScriptLibrary" => L("Main.Header.ScriptLibrary", "Script Library"),
+                    "settings" => L("Main.Header.Settings", "Settings"),
+                    _ => L("Main.Header.ScheduledTasks", "Scheduled Tasks")
+                };
+            }
+            else
+            {
+                NavView.Header = L("Main.Header.ScheduledTasks", "Scheduled Tasks");
+            }
         }
 
         public void OpenCreateTaskFromTemplate(ViewModels.ScriptTemplateModel template) => OpenCreateTaskDialog(template);
@@ -314,7 +389,7 @@ namespace FluentTaskScheduler
                 ViewModel.SetFilter(folder.Path);
                 
                 // Restore Task View
-                NavView.Header = "计划任务";
+                NavView.Header = L("Main.Header.ScheduledTasks", "Scheduled Tasks");
                 TasksViewGrid.Visibility = Visibility.Visible;
                 ContentFrame.Visibility = Visibility.Collapsed;
                 
@@ -327,7 +402,7 @@ namespace FluentTaskScheduler
         {
             if (args.IsSettingsSelected || (args.SelectedItem is NavigationViewItem settingsItem && settingsItem.Tag?.ToString() == "settings")) 
             {
-                 NavView.Header = "设置";
+                 NavView.Header = L("Main.Header.Settings", "Settings");
                  ContentFrame.Visibility = Visibility.Visible;
                  TasksViewGrid.Visibility = Visibility.Collapsed;
                  ContentFrame.Navigate(typeof(SettingsPage));
@@ -338,7 +413,7 @@ namespace FluentTaskScheduler
 
                 if (tag == "Dashboard")
                 {
-                    NavView.Header = "仪表盘";
+                    NavView.Header = L("Main.Header.Dashboard", "Dashboard");
                     TasksViewGrid.Visibility = Visibility.Collapsed;
                     ContentFrame.Visibility = Visibility.Visible;
                     ContentFrame.Navigate(typeof(DashboardPage));
@@ -346,7 +421,7 @@ namespace FluentTaskScheduler
                 }
                 else if (tag == "ScriptLibrary")
                 {
-                    NavView.Header = "脚本库";
+                    NavView.Header = L("Main.Header.ScriptLibrary", "Script Library");
                     TasksViewGrid.Visibility = Visibility.Collapsed;
                     ContentFrame.Visibility = Visibility.Visible;
                     ContentFrame.Navigate(typeof(ScriptLibraryPage), this);
@@ -355,7 +430,7 @@ namespace FluentTaskScheduler
                 else
                 {
                     // Standard Task Views (if any)
-                    NavView.Header = "计划任务";
+                    NavView.Header = L("Main.Header.ScheduledTasks", "Scheduled Tasks");
                     TasksViewGrid.Visibility = Visibility.Visible;
                     ContentFrame.Visibility = Visibility.Collapsed;
                     FolderTreeView.SelectedItem = null;
@@ -389,7 +464,7 @@ namespace FluentTaskScheduler
         {
             // Switch to Tasks View
             NavView.SelectedItem = null; // Clear selection to indicate custom state or select "All Tasks"
-            NavView.Header = "计划任务";
+            NavView.Header = L("Main.Header.ScheduledTasks", "Scheduled Tasks");
             TasksViewGrid.Visibility = Visibility.Visible;
             ContentFrame.Visibility = Visibility.Collapsed;
             FolderTreeView.SelectedItem = null;
@@ -453,7 +528,7 @@ namespace FluentTaskScheduler
             if (BatchActionBar != null)
             {
                 BatchActionBar.Visibility = count > 1 ? Visibility.Visible : Visibility.Collapsed;
-                if (BatchCountText != null) BatchCountText.Text = $"已选择 {count} 项";
+                if (BatchCountText != null) BatchCountText.Text = $"{count} selected";
                 UpdateBatchActionsState();
             }
             if (count == 1) ViewModel.SelectedTask = (ScheduledTaskModel)TaskListView.SelectedItem;
@@ -620,10 +695,10 @@ namespace FluentTaskScheduler
              var dp = new DataPackage();
              dp.SetText(string.Join("\n", _fullHistory.Select(h => $"{h.Time}\t{h.Result}\t{h.Message}")));
              Clipboard.SetContent(dp);
-             CopyHistoryBtn.Content = L("Main.HistoryCopied", "✅ Copied!");
+             CopyHistoryBtn.Content = L("Main.History.Copied", "✅ Copied!");
              await Task.Delay(2000);
-             CopyHistoryBtn.Content = L("Main.HistoryCopy", "📋 Copy");
-        }
+             CopyHistoryBtn.Content = L("Main.History.Copy", "📋 Copy");
+         }
         
         private void StatTotal_Tapped(object sender, TappedRoutedEventArgs e) { _historyStatusFilter = "Total"; UpdateHistoryList(); }
         private void StatSuccess_Tapped(object sender, TappedRoutedEventArgs e) { _historyStatusFilter = "Success"; UpdateHistoryList(); }
@@ -733,10 +808,10 @@ namespace FluentTaskScheduler
 
             var dialog = new ContentDialog 
             { 
-                Title = L("Main.ConfirmDelete.Title", "Confirm Delete"), 
-                Content = string.Format(L("Main.ConfirmDelete.Content", "Are you sure you want to delete '{0}'?"), ViewModel.SelectedTask.Name), 
-                PrimaryButtonText = L("Dialog.Delete", "Delete"), 
-                CloseButtonText = L("Dialog.Cancel", "Cancel"), 
+                Title = L("Dialog.ConfirmDelete.Title", "Confirm Delete"), 
+                Content = string.Format(L("Dialog.DeleteTask.ContentFormat", "Are you sure you want to delete '{0}'?"), ViewModel.SelectedTask.Name), 
+                PrimaryButtonText = L("Dialog.Common.Delete", "Delete"), 
+                CloseButtonText = L("Dialog.Common.Cancel", "Cancel"), 
                 DefaultButton = ContentDialogButton.Close, 
                 XamlRoot = this.XamlRoot 
             };
@@ -813,15 +888,15 @@ namespace FluentTaskScheduler
                 };
 
                 var panel = new StackPanel();
-                panel.Children.Add(new TextBlock { Text = L("Main.ImportTask.SelectFolder", "Select the folder to import this task into:") });
+                panel.Children.Add(new TextBlock { Text = L("Dialog.ImportTask.SelectFolder", "Select the folder to import this task into:") });
                 panel.Children.Add(comboBox);
 
                 var dialog = new ContentDialog
                 {
-                    Title = L("Main.ImportTask.Title", "Import Task"),
+                    Title = L("Dialog.ImportTask.Title", "Import Task"),
                     Content = panel,
-                    PrimaryButtonText = L("Dialog.Import", "Import"),
-                    CloseButtonText = L("Dialog.Cancel", "Cancel"),
+                    PrimaryButtonText = L("Dialog.Common.Import", "Import"),
+                    CloseButtonText = L("Dialog.Common.Cancel", "Cancel"),
                     DefaultButton = ContentDialogButton.Primary,
                     XamlRoot = this.XamlRoot
                 };
@@ -1138,7 +1213,7 @@ namespace FluentTaskScheduler
                 // Non-admin: disable dropdown and show explanation notice
                 EditTaskNetworkSelection.IsEnabled = false;
                 EditTaskNetworkSelection.Items.Clear();
-                EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = L("Main.AnyNetwork", "Any network"), Tag = "" });
+                EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = L("Main.Network.Any", "Any network"), Tag = "" });
                 EditTaskNetworkSelection.SelectedIndex = 0;
                 NetworkAdminNotice.IsOpen = true;
                 return;
@@ -1148,7 +1223,7 @@ namespace FluentTaskScheduler
             NetworkAdminNotice.IsOpen = false;
             EditTaskNetworkSelection.IsEnabled = true;
             EditTaskNetworkSelection.Items.Clear();
-            EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = L("Main.AnyNetwork", "Any network"), Tag = "" });
+            EditTaskNetworkSelection.Items.Add(new ComboBoxItem { Content = L("Main.Network.Any", "Any network"), Tag = "" });
 
             try
             {
@@ -1345,17 +1420,25 @@ namespace FluentTaskScheduler
             }
         }
         private void BatchStop_Click(object sender, RoutedEventArgs e) => PerformBatchAction(t => { ViewModel.TaskService.StopTask(t.Path); t.State = "Ready"; });
-        private async void BatchEnable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (!t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, true); t.IsEnabled = true; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog(string.Format(L("Main.PermissionEnableDenied", "The user account under which you are performing this action does not have permission to enable the following task(s):\n\n{0}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."), string.Join("\n", denied))); }
-        private async void BatchDisable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, false); t.IsEnabled = false; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog(string.Format(L("Main.PermissionDisableDenied", "The user account under which you are performing this action does not have permission to disable the following task(s):\n\n{0}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."), string.Join("\n", denied))); }
-        private async void BatchDelete_Click(object sender, RoutedEventArgs e) 
-        { 
-             var tasks = TaskListView.SelectedItems.Cast<ScheduledTaskModel>().ToList();
-             var dialog = new ContentDialog { Title = L("Main.ConfirmDelete.Title", "Confirm Delete"), Content = string.Format(L("Main.BatchDelete.Content", "Delete {0} tasks?"), tasks.Count), PrimaryButtonText = L("Dialog.Delete", "Delete"), CloseButtonText = L("Dialog.Cancel", "Cancel"), DefaultButton = ContentDialogButton.Close, XamlRoot = this.XamlRoot };
-             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
-             {
-                 foreach(var t in tasks) try { ViewModel.TaskService.DeleteTask(t.Path); } catch {}
-                 _ = ViewModel.LoadTasksAsync();
-             }
+        private async void BatchEnable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (!t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, true); t.IsEnabled = true; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog($"The user account under which you are performing this action does not have permission to enable the following task(s):\n\n{string.Join("\n", denied)}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."); }
+        private async void BatchDisable_Click(object sender, RoutedEventArgs e) { var denied = PerformBatchActionWithErrors(t => { if (t.IsEnabled) { ViewModel.TaskService.SetTaskEnabled(t.Path, false); t.IsEnabled = false; } }); UpdateBatchActionsState(); if (denied.Count > 0) await ShowErrorDialog($"The user account under which you are performing this action does not have permission to disable the following task(s):\n\n{string.Join("\n", denied)}\n\nThese tasks are protected and cannot be modified, even with administrator privileges."); }
+        private async void BatchDelete_Click(object sender, RoutedEventArgs e)
+        {
+            var tasks = TaskListView.SelectedItems.Cast<ScheduledTaskModel>().ToList();
+            var dialog = new ContentDialog
+            {
+                Title = L("Dialog.ConfirmDelete.Title", "Confirm Delete"),
+                Content = string.Format(L("Dialog.BatchDelete.ContentFormat", "Delete {0} tasks?"), tasks.Count),
+                PrimaryButtonText = L("Dialog.Common.Delete", "Delete"),
+                CloseButtonText = L("Dialog.Common.Cancel", "Cancel"),
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = this.XamlRoot
+            };
+            if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+            {
+                foreach (var t in tasks) try { ViewModel.TaskService.DeleteTask(t.Path); } catch { }
+                _ = ViewModel.LoadTasksAsync();
+            }
         }
         private void PerformBatchAction(System.Action<ScheduledTaskModel> action) { foreach (var task in TaskListView.SelectedItems.Cast<ScheduledTaskModel>().ToList()) try { action(task); } catch { } }
         private List<string> PerformBatchActionWithErrors(System.Action<ScheduledTaskModel> action) { var denied = new List<string>(); foreach (var task in TaskListView.SelectedItems.Cast<ScheduledTaskModel>().ToList()) try { action(task); } catch (UnauthorizedAccessException) { denied.Add(task.Name); } catch { } return denied; }
@@ -1387,7 +1470,7 @@ namespace FluentTaskScheduler
         {
             var flyout = new MenuFlyout();
             string arrow(string col) =>
-                ViewModel.SortColumn == col ? (ViewModel.SortAscending ? " â–²" : " â–¼") : "";
+                ViewModel.SortColumn == col ? (ViewModel.SortAscending ? " ▲" : " ▼") : "";
 
             void AddItem(string label, string col)
             {
@@ -1396,12 +1479,12 @@ namespace FluentTaskScheduler
                 flyout.Items.Add(item);
             }
 
-            AddItem("名称",         "Name");
-            AddItem("状态",       "Status");
-            AddItem("下次运行",     "NextRun");
-            AddItem("上次运行",     "LastRun");
+            AddItem(L("Main.Sort.Name", "Name"), "Name");
+            AddItem(L("Main.Sort.Status", "Status"), "Status");
+            AddItem(L("Main.Sort.NextRun", "Next Run"), "NextRun");
+            AddItem(L("Main.Sort.LastRun", "Last Run"), "LastRun");
             flyout.Items.Add(new MenuFlyoutSeparator());
-            var clear = new MenuFlyoutItem { Text = "清除排序" };
+            var clear = new MenuFlyoutItem { Text = L("Main.Sort.Clear", "Clear Sort") };
             clear.Click += (s, _) => { ViewModel.ClearSort(); UpdateSortButtonText(); };
             flyout.Items.Add(clear);
 
@@ -1410,10 +1493,10 @@ namespace FluentTaskScheduler
 
         private void UpdateSortButtonText()
         {
-            string arrow = ViewModel.SortAscending ? "â–²" : "â–¼";
+            string arrow = ViewModel.SortAscending ? "▲" : "▼";
             SortButton.Content = string.IsNullOrEmpty(ViewModel.SortColumn)
-                ? "排序 \u2195"
-                : $"排序 {arrow} {ViewModel.SortColumn}";
+                ? L("Main.Toolbar.SortButton", "Sort ↕")
+                : string.Format(L("Main.Toolbar.SortActiveFormat", "Sort {0} {1}"), arrow, ViewModel.SortColumn);
         }
 
         private async void ReloadFolders_Click(object sender, RoutedEventArgs e)
@@ -1479,7 +1562,16 @@ namespace FluentTaskScheduler
 
         private async void CreateFolder_Click(string parentPath)
         {
-            var dialog = new ContentDialog { Title=L("Main.NewFolder.Title", "New Folder"), Content=new TextBox{PlaceholderText=L("Main.NewFolder.NamePlaceholder", "Name")}, PrimaryButtonText=L("Dialog.Create", "Create"), CloseButtonText=L("Dialog.Cancel", "Cancel"), DefaultButton=ContentDialogButton.Primary, XamlRoot=this.XamlRoot, RequestedTheme=Services.SettingsService.Theme };
+            var dialog = new ContentDialog
+            {
+                Title = L("Dialog.NewFolder.Title", "New Folder"),
+                Content = new TextBox { PlaceholderText = L("Dialog.NewFolder.NamePlaceholder", "Name") },
+                PrimaryButtonText = L("Dialog.Common.Create", "Create"),
+                CloseButtonText = L("Dialog.Common.Cancel", "Cancel"),
+                DefaultButton = ContentDialogButton.Primary,
+                XamlRoot = this.XamlRoot,
+                RequestedTheme = Services.SettingsService.Theme
+            };
             if (await dialog.ShowAsync() == ContentDialogResult.Primary && dialog.Content is TextBox tb && !string.IsNullOrWhiteSpace(tb.Text)) 
             { 
                 try 
@@ -1496,15 +1588,15 @@ namespace FluentTaskScheduler
 
         private async void RenameFolder_Click(string path, string oldName)
         {
-            var tb = new TextBox { Text = oldName, PlaceholderText = L("Main.RenameFolder.NamePlaceholder", "New Name") };
+            var tb = new TextBox { Text = oldName, PlaceholderText = L("Dialog.RenameFolder.NewNamePlaceholder", "New Name") };
             tb.SelectAll();
             
             var dialog = new ContentDialog
             {
-                Title = L("Main.RenameFolder.Title", "Rename Folder"),
+                Title = L("Dialog.RenameFolder.Title", "Rename Folder"),
                 Content = tb,
-                PrimaryButtonText = L("Dialog.Rename", "Rename"),
-                CloseButtonText = L("Dialog.Cancel", "Cancel"),
+                PrimaryButtonText = L("Dialog.Common.Rename", "Rename"),
+                CloseButtonText = L("Dialog.Common.Cancel", "Cancel"),
                 DefaultButton = ContentDialogButton.Primary,
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = Services.SettingsService.Theme
@@ -1533,7 +1625,16 @@ namespace FluentTaskScheduler
 
         private async void DeleteFolder_Click(string path)
         {
-            var dialog = new ContentDialog { Title=L("Main.DeleteFolder.Title", "Delete Folder"), Content=string.Format(L("Main.DeleteFolder.Content", "Delete '{0}' and ALL tasks in it?"), path), PrimaryButtonText=L("Dialog.Delete", "Delete"), CloseButtonText=L("Dialog.Cancel", "Cancel"), DefaultButton=ContentDialogButton.Close, XamlRoot=this.XamlRoot, RequestedTheme=Services.SettingsService.Theme };
+            var dialog = new ContentDialog
+            {
+                Title = L("Dialog.DeleteFolder.Title", "Delete Folder"),
+                Content = string.Format(L("Dialog.DeleteFolder.ContentFormat", "Delete '{0}' and ALL tasks in it?"), path),
+                PrimaryButtonText = L("Dialog.Common.Delete", "Delete"),
+                CloseButtonText = L("Dialog.Common.Cancel", "Cancel"),
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = this.XamlRoot,
+                RequestedTheme = Services.SettingsService.Theme
+            };
             if (await dialog.ShowAsync() == ContentDialogResult.Primary) 
             { 
                 try 
@@ -1857,7 +1958,7 @@ namespace FluentTaskScheduler
             LoadFolderStructure();
 
             if (errors.Count > 0)
-                await ShowErrorDialog(L("Main.MoveTasksPartialError", "Some tasks could not be moved:\n\n") + string.Join("\n", errors));
+                await ShowErrorDialog("Some tasks could not be moved:\n\n" + string.Join("\n", errors));
         }
 
         private async System.Threading.Tasks.Task MoveDraggedFolderAsync(string sourceFolderPath, string targetFolderPath)
@@ -1871,7 +1972,7 @@ namespace FluentTaskScheduler
                 LoadFolderStructure();
                 await ViewModel.LoadTasksAsync();
             }
-            catch (Exception ex) { await ShowErrorDialog(string.Format(L("Main.MoveFolderError", "Could not move folder: {0}"), ex.Message)); }
+            catch (Exception ex) { await ShowErrorDialog($"Could not move folder: {ex.Message}"); }
         }
 
 
@@ -1883,9 +1984,9 @@ namespace FluentTaskScheduler
             { 
                 var dialog = new ContentDialog 
                 { 
-                    Title = L("Main.Error.Title", "Error"), 
+                    Title = L("Dialog.Error.Title", "Error"), 
                     Content = message, 
-                    CloseButtonText = L("Dialog.OK", "OK"), 
+                    CloseButtonText = L("Dialog.Common.OK", "OK"), 
                     XamlRoot = this.XamlRoot, 
                     RequestedTheme = Services.SettingsService.Theme 
                 };
@@ -2078,4 +2179,3 @@ namespace FluentTaskScheduler
         }
     }
 }
-

--- a/ScriptLibraryPage.xaml
+++ b/ScriptLibraryPage.xaml
@@ -15,8 +15,8 @@
 
                 <!-- Header row -->
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <TextBlock Text="Script Library" Style="{StaticResource SubtitleTextBlockStyle}" VerticalAlignment="Center"/>
-                    <Button x:Name="CreateTemplateButton" Content="+ New Template" Click="CreateTemplateButton_Click"/>
+                    <TextBlock Text="脚本库" Style="{StaticResource SubtitleTextBlockStyle}" VerticalAlignment="Center"/>
+                    <Button x:Name="CreateTemplateButton" Content="+ 新建模板" Click="CreateTemplateButton_Click"/>
                 </StackPanel>
 
                 <!-- Template cards grid -->
@@ -51,14 +51,14 @@
                                             BorderThickness="0"
                                             Padding="4"
                                             VerticalAlignment="Top"
-                                            ToolTipService.ToolTip="Delete template">
+                                            ToolTipService.ToolTip="删除模板">
                                         <FontIcon Glyph="&#xE74D;" FontSize="12" Foreground="{ThemeResource SystemFillColorCriticalBrush}"/>
                                     </Button>
                                 </Grid>
                                 
                                 <TextBlock Grid.Row="1" Text="{x:Bind Description}" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.7"/>
                                 
-                                <Button Grid.Row="2" Content="Schedule This" HorizontalAlignment="Stretch" Click="ScheduleButton_Click" Tag="{x:Bind}"/>
+                                <Button Grid.Row="2" Content="使用此模板创建任务" HorizontalAlignment="Stretch" Click="ScheduleButton_Click" Tag="{x:Bind}"/>
                             </Grid>
                         </DataTemplate>
                     </GridView.ItemTemplate>
@@ -68,17 +68,17 @@
 
         <!-- Create Template Dialog -->
         <ContentDialog x:Name="CreateTemplateDialog"
-                       Title="New Template"
-                       PrimaryButtonText="Save"
-                       CloseButtonText="Cancel"
+                       Title="新建模板"
+                       PrimaryButtonText="保存"
+                       CloseButtonText="取消"
                        DefaultButton="Primary"
                        PrimaryButtonClick="CreateTemplateDialog_PrimaryButtonClick">
             <StackPanel Spacing="12" MinWidth="400">
-                <TextBox x:Name="TemplateName"     Header="Name"        PlaceholderText="e.g. Cleanup Script"/>
-                <TextBox x:Name="TemplateDesc"     Header="Description" PlaceholderText="What does this template do?" TextWrapping="Wrap" AcceptsReturn="True" Height="72"/>
-                <TextBox x:Name="TemplateCommand"  Header="Command"     PlaceholderText="e.g. powershell.exe"/>
-                <TextBox x:Name="TemplateArgs"     Header="Arguments"   PlaceholderText="e.g. -File C:\scripts\cleanup.ps1"/>
-                <CheckBox x:Name="TemplateAdmin"   Content="Run with highest privileges"/>
+                <TextBox x:Name="TemplateName"     Header="名称"        PlaceholderText="例如：清理脚本"/>
+                <TextBox x:Name="TemplateDesc"     Header="描述" PlaceholderText="这个模板用于做什么？" TextWrapping="Wrap" AcceptsReturn="True" Height="72"/>
+                <TextBox x:Name="TemplateCommand"  Header="命令"     PlaceholderText="例如：powershell.exe"/>
+                <TextBox x:Name="TemplateArgs"     Header="参数"   PlaceholderText="例如：-File C:\scripts\cleanup.ps1"/>
+                <CheckBox x:Name="TemplateAdmin"   Content="以最高权限运行"/>
             </StackPanel>
         </ContentDialog>
     </Grid>

--- a/ScriptLibraryPage.xaml.cs
+++ b/ScriptLibraryPage.xaml.cs
@@ -7,6 +7,7 @@ namespace FluentTaskScheduler
     public sealed partial class ScriptLibraryPage : Page
     {
         public ScriptLibraryViewModel ViewModel { get; } = new();
+        private static string L(string key, string fallback) => Services.LocalizationService.GetString(key, fallback);
 
         private MainPage? _ownerMainPage;
 
@@ -67,10 +68,10 @@ namespace FluentTaskScheduler
 
             var confirm = new ContentDialog
             {
-                Title           = "Delete Template",
-                Content         = $"Delete '{template.Name}'?",
-                PrimaryButtonText = "Delete",
-                CloseButtonText = "Cancel",
+                Title           = L("ScriptLibrary.DeleteTemplate.Title", "Delete Template"),
+                Content         = string.Format(L("ScriptLibrary.DeleteTemplate.Content", "Delete '{0}'?"), template.Name),
+                PrimaryButtonText = L("Dialog.Delete", "Delete"),
+                CloseButtonText = L("Dialog.Cancel", "Cancel"),
                 DefaultButton   = ContentDialogButton.Close,
                 XamlRoot        = this.XamlRoot
             };

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -1,0 +1,26 @@
+using Windows.ApplicationModel.Resources;
+
+namespace FluentTaskScheduler.Services
+{
+    public static class LocalizationService
+    {
+        private static readonly ResourceLoader Loader = ResourceLoader.GetForViewIndependentUse();
+
+        public static string GetString(string key, string fallback = "")
+        {
+            try
+            {
+                var value = Loader.GetString(key);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+            }
+            catch
+            {
+            }
+
+            return string.IsNullOrEmpty(fallback) ? key : fallback;
+        }
+    }
+}

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -1,26 +1,142 @@
+using System;
+using System.Collections.Generic;
 using Windows.ApplicationModel.Resources;
+using Windows.ApplicationModel.Resources.Core;
 
 namespace FluentTaskScheduler.Services
 {
     public static class LocalizationService
     {
-        private static readonly ResourceLoader Loader = ResourceLoader.GetForViewIndependentUse();
+        private static readonly HashSet<string> _supportedLanguages = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "en-US",
+            "zh-CN"
+        };
+
+        private static string _currentLanguage = "en-US";
+
+        public static event EventHandler? LanguageChanged;
+
+        public static string CurrentLanguage => _currentLanguage;
+
+        public static void Initialize()
+        {
+            ApplyLanguage(NormalizeLanguage(SettingsService.Language), raiseEvent: false);
+        }
+
+        public static bool ChangeLanguage(string language)
+        {
+            string normalized = NormalizeLanguage(language);
+            if (string.Equals(_currentLanguage, normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            ApplyLanguage(normalized, raiseEvent: true);
+            return true;
+        }
 
         public static string GetString(string key, string fallback = "")
         {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return fallback;
+            }
+
+            string? localized = ResolveString(key);
+            if (!string.IsNullOrWhiteSpace(localized))
+            {
+                return localized;
+            }
+
+            string slashKey = key.Replace('.', '/');
+            if (!string.Equals(slashKey, key, StringComparison.Ordinal))
+            {
+                localized = ResolveString(slashKey);
+                if (!string.IsNullOrWhiteSpace(localized))
+                {
+                    return localized;
+                }
+            }
+
             try
             {
-                var value = Loader.GetString(key);
-                if (!string.IsNullOrEmpty(value))
+                string value = ResourceLoader.GetForViewIndependentUse().GetString(key);
+                if (!string.IsNullOrWhiteSpace(value))
                 {
                     return value;
                 }
             }
             catch
             {
+                // Ignore and fall back.
             }
 
             return string.IsNullOrEmpty(fallback) ? key : fallback;
+        }
+
+        private static string? ResolveString(string key)
+        {
+            try
+            {
+                var context = ResourceContext.GetForViewIndependentUse();
+                context.Languages = new[] { _currentLanguage };
+
+                ResourceMap rootMap = ResourceManager.Current.MainResourceMap;
+                ResourceMap? resourceMap = null;
+                try
+                {
+                    resourceMap = rootMap.GetSubtree("Resources");
+                }
+                catch
+                {
+                    resourceMap = rootMap;
+                }
+
+                var candidate = resourceMap.GetValue(key, context);
+                string? value = candidate?.ValueAsString;
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+            catch
+            {
+                // Ignore and let fallback pipeline continue.
+            }
+
+            return null;
+        }
+
+        private static void ApplyLanguage(string language, bool raiseEvent)
+        {
+            _currentLanguage = language;
+            SettingsService.Language = language;
+
+            try
+            {
+                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = language;
+                ResourceContext.SetGlobalQualifierValue("Language", language);
+            }
+            catch
+            {
+                // Ignore override failures and keep app running.
+            }
+
+            if (raiseEvent)
+            {
+                LanguageChanged?.Invoke(null, EventArgs.Empty);
+            }
+        }
+
+        private static string NormalizeLanguage(string? language)
+        {
+            if (!string.IsNullOrWhiteSpace(language) && _supportedLanguages.Contains(language))
+            {
+                return language;
+            }
+
+            return "en-US";
         }
     }
 }

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -11,7 +11,7 @@ namespace FluentTaskScheduler.Services
         public string Theme { get; set; } = "Default";
         public bool IsOledMode { get; set; } = false;
         public bool IsMicaEnabled { get; set; } = true;
-        public string Language { get; set; } = "en-US";
+        public string Language { get; set; } = "zh-CN";
         public bool ConfirmDelete { get; set; } = true;
         public bool ShowNotifications { get; set; } = true;
         public bool EnableTrayIcon { get; set; } = true;

--- a/SettingsPage.xaml
+++ b/SettingsPage.xaml
@@ -96,6 +96,21 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
+                                    <TextBlock x:Uid="SettingsLanguageTitle" Text="Language" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock x:Uid="SettingsLanguageHint" Text="Select UI language. Restart the app to apply all text changes." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <ComboBox x:Name="LanguageComboBox" Grid.Column="1" VerticalAlignment="Center"
+                                          SelectionChanged="LanguageComboBox_SelectionChanged" Width="160">
+                                    <ComboBoxItem x:Uid="SettingsLanguageEnglish" Content="English"/>
+                                    <ComboBoxItem x:Uid="SettingsLanguageChinese" Content="简体中文"/>
+                                </ComboBox>
+                            </Grid>
+                        </Border>
+
+                        <Border Style="{StaticResource SettingsCardStyle}">
+                            <Grid>
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
+                                <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
                                     <TextBlock Text="Mica Effect" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                                     <TextBlock Text="Apply the Mica translucent background material." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>

--- a/SettingsPage.xaml
+++ b/SettingsPage.xaml
@@ -29,37 +29,37 @@
                         Padding="0">
             
             <NavigationView.MenuItems>
-                <NavigationViewItem Tag="Appearance" Content="Appearance" IsSelected="True">
+                <NavigationViewItem Tag="Appearance" Content="外观" IsSelected="True">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE790;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Notifications" Content="Notifications">
+                <NavigationViewItem Tag="Notifications" Content="通知">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7E7;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="System" Content="System">
+                <NavigationViewItem Tag="System" Content="系统">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE770;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Advanced" Content="Advanced">
+                <NavigationViewItem Tag="Advanced" Content="高级">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE90F;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Data" Content="Data">
+                <NavigationViewItem Tag="Data" Content="数据">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8B5;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Categories" Content="Categories &amp; Tags">
+                <NavigationViewItem Tag="Categories" Content="分类与标签">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8EC;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="About" Content="About">
+                <NavigationViewItem Tag="About" Content="关于">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE946;"/>
                     </NavigationViewItem.Icon>
@@ -74,20 +74,20 @@
 
                     <!-- ── Appearance ── -->
                     <StackPanel x:Name="PanelAppearance" Spacing="4">
-                        <TextBlock Text="Appearance" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="外观" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="App Theme" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Choose Light, Dark, or follow the system setting." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="应用主题" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="可选择浅色、深色，或跟随系统设置。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ComboBox x:Name="ThemeComboBox" Grid.Column="1" VerticalAlignment="Center"
                                           SelectionChanged="ThemeComboBox_SelectionChanged" Width="160">
-                                    <ComboBoxItem Content="Light"/>
-                                    <ComboBoxItem Content="Dark"/>
-                                    <ComboBoxItem Content="System Default"/>
+                                    <ComboBoxItem Content="浅色"/>
+                                    <ComboBoxItem Content="深色"/>
+                                    <ComboBoxItem Content="跟随系统"/>
                                 </ComboBox>
                             </Grid>
                         </Border>
@@ -96,8 +96,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock x:Uid="SettingsLanguageTitle" Text="Language" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock x:Uid="SettingsLanguageHint" Text="Select UI language. Restart the app to apply all text changes." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock x:Uid="SettingsLanguageTitle" Text="语言" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock x:Uid="SettingsLanguageHint" Text="选择界面语言。重启应用后将完全生效。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ComboBox x:Name="LanguageComboBox" Grid.Column="1" VerticalAlignment="Center"
                                           SelectionChanged="LanguageComboBox_SelectionChanged" Width="160">
@@ -111,8 +111,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Mica Effect" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Apply the Mica translucent background material." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Mica 效果" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="启用 Mica 半透明背景材质。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="MicaModeToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="MicaModeToggle_Toggled"/>
@@ -123,8 +123,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="OLED Mode" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Pure black background to save power on OLED displays. Requires Dark theme." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="OLED 模式" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="纯黑背景可降低 OLED 屏幕功耗（需深色主题）。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="OledModeToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" Toggled="OledModeToggle_Toggled"/>
@@ -134,14 +134,14 @@
 
                     <!-- ── Notifications ── -->
                     <StackPanel x:Name="PanelNotifications" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="Notifications" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="通知" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Task Notifications" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Show a toast when a task starts or fails." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="任务通知" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="任务开始或失败时显示通知。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="NotificationsToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="NotificationsToggle_Toggled"/>
@@ -152,8 +152,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Upcoming Task Reminders" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Show a reminder toast before a scheduled task is about to run." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="即将运行提醒" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="计划任务即将运行前显示提醒通知。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="UpcomingRemindersToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="UpcomingRemindersToggle_Toggled"/>
@@ -164,16 +164,16 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Reminder Timing" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="How far in advance to send the reminder." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="提醒时间" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="设置提前多久发送提醒。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ComboBox x:Name="ReminderLeadTimeComboBox" Grid.Column="1" VerticalAlignment="Center"
                                           SelectionChanged="ReminderLeadTimeComboBox_SelectionChanged" Width="160">
-                                    <ComboBoxItem Content="1 minute before"/>
-                                    <ComboBoxItem Content="5 minutes before"/>
-                                    <ComboBoxItem Content="10 minutes before"/>
-                                    <ComboBoxItem Content="15 minutes before"/>
-                                    <ComboBoxItem Content="30 minutes before"/>
+                                    <ComboBoxItem Content="提前 1 分钟"/>
+                                    <ComboBoxItem Content="提前 5 分钟"/>
+                                    <ComboBoxItem Content="提前 10 分钟"/>
+                                    <ComboBoxItem Content="提前 15 分钟"/>
+                                    <ComboBoxItem Content="提前 30 分钟"/>
                                 </ComboBox>
                             </Grid>
                         </Border>
@@ -181,14 +181,14 @@
 
                     <!-- ── System ── -->
                     <StackPanel x:Name="PanelSystem" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="System" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="系统" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Run on Startup" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Automatically launch the app when you sign in to Windows." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="开机启动" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="登录 Windows 后自动启动应用。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="RunOnStartupToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="False" Toggled="RunOnStartupToggle_Toggled"/>
@@ -199,8 +199,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Minimize to Tray" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Hide the window to the system tray instead of closing." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="最小化到托盘" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="关闭窗口时隐藏到系统托盘而不是退出。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="TrayIconToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="TrayIconToggle_Toggled"/>
@@ -211,8 +211,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Smooth Scrolling" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Enable inertia-based scrolling throughout the app." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="平滑滚动" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="在应用中启用惯性滚动效果。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="SmoothScrollingToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="False" Toggled="SmoothScrollingToggle_Toggled"/>
@@ -223,8 +223,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Show Hidden Tasks" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Display tasks that are marked as hidden in the Windows Task Scheduler." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="显示隐藏任务" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="显示在 Windows 任务计划程序中被标记为隐藏的任务。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="ShowHiddenTasksToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="ShowHiddenTasksToggle_Toggled"/>
@@ -234,14 +234,14 @@
 
                     <!-- ── Advanced ── -->
                     <StackPanel x:Name="PanelAdvanced" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="Advanced" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="高级" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Confirm Before Deleting" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Show a confirmation dialog before removing a task." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="删除前确认" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="删除任务前弹出确认对话框。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="ConfirmDeleteToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" Toggled="ConfirmDeleteToggle_Toggled"/>
@@ -252,8 +252,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Application Logging" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Write internal events and errors to a log file for troubleshooting." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="应用日志" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="将内部事件和错误写入日志文件，便于排查问题。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
                                     <ToggleSwitch x:Name="LoggingToggle" OffContent="" OnContent="" IsOn="True" Toggled="LoggingToggle_Toggled"/>
@@ -265,8 +265,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Separate Log Files" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Store error and crash logs in dedicated files instead of the main log." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="分离日志文件" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="错误与崩溃日志单独存储，不写入主日志文件。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="SeparateLogsToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="SeparateLogsToggle_Toggled"/>
@@ -277,13 +277,13 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Specific Logs" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Direct access to error and crash records." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="专项日志" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="快速访问错误与崩溃日志。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-                                    <Button x:Name="OpenLogButton" Content="Open Log" Click="OpenLogButton_Click"/>
-                                    <Button x:Name="OpenErrorLogButton" Content="Open Error Log" Click="OpenErrorLogButton_Click"/>
-                                    <Button x:Name="OpenCrashLogButton" Content="Open Crash Log" Click="OpenCrashLogButton_Click"/>
+                                    <Button x:Name="OpenLogButton" Content="打开日志" Click="OpenLogButton_Click"/>
+                                    <Button x:Name="OpenErrorLogButton" Content="打开错误日志" Click="OpenErrorLogButton_Click"/>
+                                    <Button x:Name="OpenCrashLogButton" Content="打开崩溃日志" Click="OpenCrashLogButton_Click"/>
                                 </StackPanel>
                             </Grid>
                         </Border>
@@ -291,16 +291,16 @@
 
                     <!-- ── Data ── -->
                     <StackPanel x:Name="PanelData" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="Data" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="数据" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Export Settings" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Save your current settings to a JSON file." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="导出设置" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="将当前设置保存为 JSON 文件。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
-                                <Button x:Name="ExportSettingsButton" Grid.Column="1" Content="Export" VerticalAlignment="Center" Click="ExportSettings_Click"/>
+                                <Button x:Name="ExportSettingsButton" Grid.Column="1" Content="导出" VerticalAlignment="Center" Click="ExportSettings_Click"/>
                             </Grid>
                         </Border>
 
@@ -308,30 +308,30 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Import Settings" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Restore settings from a previously exported file." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="导入设置" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="从之前导出的文件恢复设置。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
-                                <Button x:Name="ImportSettingsButton" Grid.Column="1" Content="Import" VerticalAlignment="Center" Click="ImportSettings_Click"/>
+                                <Button x:Name="ImportSettingsButton" Grid.Column="1" Content="导入" VerticalAlignment="Center" Click="ImportSettings_Click"/>
                             </Grid>
                         </Border>
                     </StackPanel>
 
                     <!-- ── Categories & Tags ── -->
                     <StackPanel x:Name="PanelCategories" Spacing="16" Visibility="Collapsed">
-                        <TextBlock Text="Categories &amp; Tags" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="分类与标签" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <!-- Categories Section -->
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <StackPanel Spacing="12">
-                                <TextBlock Text="Manage Categories" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                <TextBlock Text="Predefined categories for your tasks." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
+                                <TextBlock Text="管理分类" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="为任务预设分类。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox x:Name="NewCategoryBox" PlaceholderText="New category name..." KeyDown="NewCategoryBox_KeyDown"/>
-                                    <Button x:Name="AddCategoryBtn" Grid.Column="1" Content="Add" Click="AddCategory_Click"/>
+                                    <TextBox x:Name="NewCategoryBox" PlaceholderText="新分类名称..." KeyDown="NewCategoryBox_KeyDown"/>
+                                    <Button x:Name="AddCategoryBtn" Grid.Column="1" Content="添加" Click="AddCategory_Click"/>
                                 </Grid>
                                 <ItemsControl x:Name="CategoriesItemsControl">
                                     <ItemsControl.ItemsPanel>
@@ -360,15 +360,15 @@
                         <!-- Tags Section -->
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <StackPanel Spacing="12">
-                                <TextBlock Text="Manage Tags" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                <TextBlock Text="Predefined tags for your tasks." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
+                                <TextBlock Text="管理标签" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="为任务预设标签。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox x:Name="NewTagBox" PlaceholderText="New tag name..." KeyDown="NewTagBox_KeyDown"/>
-                                    <Button x:Name="AddTagBtn" Grid.Column="1" Content="Add" Click="AddTag_Click"/>
+                                    <TextBox x:Name="NewTagBox" PlaceholderText="新标签名称..." KeyDown="NewTagBox_KeyDown"/>
+                                    <Button x:Name="AddTagBtn" Grid.Column="1" Content="添加" Click="AddTag_Click"/>
                                 </Grid>
                                 <ItemsControl x:Name="TagsItemsControl">
                                     <ItemsControl.ItemsPanel>
@@ -397,18 +397,18 @@
 
                     <!-- ── About ── -->
                     <StackPanel x:Name="PanelAbout" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="About" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock Text="关于" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center">
-                                    <TextBlock Text="Fluent Task Scheduler" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Built with WinUI 3 · Windows App SDK" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
+                                     <TextBlock Text="Fluent Task Scheduler" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                     <TextBlock Text="基于 WinUI 3 · Windows App SDK 构建" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
                                 </StackPanel>
                                 <Button x:Name="VersionButton" Grid.Column="1" Click="VersionButton_Click"
                                         Background="Transparent" BorderThickness="0" Padding="8,6"
-                                        VerticalAlignment="Center" ToolTipService.ToolTip="See What's New">
+                                         VerticalAlignment="Center" ToolTipService.ToolTip="查看更新内容">
                                     <StackPanel Orientation="Horizontal" Spacing="4">
                                         <TextBlock x:Uid="AboutVersion" Text="Version 1.8.1"
                                                    Style="{StaticResource CaptionTextBlockStyle}"
@@ -424,15 +424,15 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Check for Updates" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Check if a newer version is available." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="检查更新" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="检查是否有可用的新版本。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                                     <ProgressRing x:Name="UpdateCheckProgressRing" IsActive="False" Width="20" Height="20" Visibility="Collapsed"/>
                                     <Button x:Name="CheckForUpdatesButton" Click="CheckForUpdates_Click">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <FontIcon Glyph="&#xE895;" FontSize="13"/>
-                                            <TextBlock Text="Check"/>
+                                            <TextBlock Text="检查"/>
                                         </StackPanel>
                                     </Button>
                                 </StackPanel>
@@ -443,14 +443,14 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Onboarding" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="Replay the welcome walkthrough from first launch." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="新手引导" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="重新播放首次启动时的欢迎引导。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <Button x:Name="ReplayOnboardingButton" Grid.Column="1" VerticalAlignment="Center"
                                         Click="ReplayOnboardingButton_Click">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
                                         <FontIcon Glyph="&#xE7C3;" FontSize="13"/>
-                                        <TextBlock Text="View Again"/>
+                                        <TextBlock Text="再次查看"/>
                                     </StackPanel>
                                 </Button>
                             </Grid>

--- a/SettingsPage.xaml
+++ b/SettingsPage.xaml
@@ -29,37 +29,37 @@
                         Padding="0">
             
             <NavigationView.MenuItems>
-                <NavigationViewItem Tag="Appearance" Content="外观" IsSelected="True">
+                <NavigationViewItem x:Name="NavAppearanceItem" Tag="Appearance" Content="Appearance" IsSelected="True">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE790;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Notifications" Content="通知">
+                <NavigationViewItem x:Name="NavNotificationsItem" Tag="Notifications" Content="Notifications">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7E7;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="System" Content="系统">
+                <NavigationViewItem x:Name="NavSystemItem" Tag="System" Content="System">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE770;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Advanced" Content="高级">
+                <NavigationViewItem x:Name="NavAdvancedItem" Tag="Advanced" Content="Advanced">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE90F;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Data" Content="数据">
+                <NavigationViewItem x:Name="NavDataItem" Tag="Data" Content="Data">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8B5;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="Categories" Content="分类与标签">
+                <NavigationViewItem x:Name="NavCategoriesItem" Tag="Categories" Content="Categories &amp; Tags">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8EC;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Tag="About" Content="关于">
+                <NavigationViewItem x:Name="NavAboutItem" Tag="About" Content="About">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE946;"/>
                     </NavigationViewItem.Icon>
@@ -74,20 +74,20 @@
 
                     <!-- ── Appearance ── -->
                     <StackPanel x:Name="PanelAppearance" Spacing="4">
-                        <TextBlock Text="外观" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="AppearanceHeaderText" Text="Appearance" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="应用主题" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="可选择浅色、深色，或跟随系统设置。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="App Theme" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Choose Light, Dark, or follow the system setting." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ComboBox x:Name="ThemeComboBox" Grid.Column="1" VerticalAlignment="Center"
                                           SelectionChanged="ThemeComboBox_SelectionChanged" Width="160">
-                                    <ComboBoxItem Content="浅色"/>
-                                    <ComboBoxItem Content="深色"/>
-                                    <ComboBoxItem Content="跟随系统"/>
+                                    <ComboBoxItem Content="Light"/>
+                                    <ComboBoxItem Content="Dark"/>
+                                    <ComboBoxItem Content="System Default"/>
                                 </ComboBox>
                             </Grid>
                         </Border>
@@ -96,13 +96,12 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock x:Uid="SettingsLanguageTitle" Text="语言" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock x:Uid="SettingsLanguageHint" Text="选择界面语言。重启应用后将完全生效。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock x:Name="LanguageTitleText" Text="Language" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock x:Name="LanguageDescriptionText" Text="Choose the display language for the app." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
-                                <ComboBox x:Name="LanguageComboBox" Grid.Column="1" VerticalAlignment="Center"
-                                          SelectionChanged="LanguageComboBox_SelectionChanged" Width="160">
-                                    <ComboBoxItem x:Uid="SettingsLanguageEnglish" Content="English"/>
-                                    <ComboBoxItem x:Uid="SettingsLanguageChinese" Content="简体中文"/>
+                                <ComboBox x:Name="LanguageComboBox" Grid.Column="1" VerticalAlignment="Center" Width="160" SelectionChanged="LanguageComboBox_SelectionChanged">
+                                    <ComboBoxItem Tag="en-US" Content="English"/>
+                                    <ComboBoxItem Tag="zh-CN" Content="简体中文"/>
                                 </ComboBox>
                             </Grid>
                         </Border>
@@ -111,8 +110,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="Mica 效果" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="启用 Mica 半透明背景材质。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Mica Effect" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Apply the Mica translucent background material." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="MicaModeToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="MicaModeToggle_Toggled"/>
@@ -123,8 +122,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="OLED 模式" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="纯黑背景可降低 OLED 屏幕功耗（需深色主题）。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="OLED Mode" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Pure black background to save power on OLED displays. Requires Dark theme." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="OledModeToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" Toggled="OledModeToggle_Toggled"/>
@@ -134,14 +133,14 @@
 
                     <!-- ── Notifications ── -->
                     <StackPanel x:Name="PanelNotifications" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="通知" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="NotificationsHeaderText" Text="Notifications" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="任务通知" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="任务开始或失败时显示通知。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Task Notifications" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Show a toast when a task starts or fails." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="NotificationsToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="NotificationsToggle_Toggled"/>
@@ -152,8 +151,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="即将运行提醒" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="计划任务即将运行前显示提醒通知。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Upcoming Task Reminders" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Show a reminder toast before a scheduled task is about to run." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="UpcomingRemindersToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="UpcomingRemindersToggle_Toggled"/>
@@ -164,16 +163,16 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="提醒时间" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="设置提前多久发送提醒。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Reminder Timing" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="How far in advance to send the reminder." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ComboBox x:Name="ReminderLeadTimeComboBox" Grid.Column="1" VerticalAlignment="Center"
                                           SelectionChanged="ReminderLeadTimeComboBox_SelectionChanged" Width="160">
-                                    <ComboBoxItem Content="提前 1 分钟"/>
-                                    <ComboBoxItem Content="提前 5 分钟"/>
-                                    <ComboBoxItem Content="提前 10 分钟"/>
-                                    <ComboBoxItem Content="提前 15 分钟"/>
-                                    <ComboBoxItem Content="提前 30 分钟"/>
+                                    <ComboBoxItem Content="1 minute before"/>
+                                    <ComboBoxItem Content="5 minutes before"/>
+                                    <ComboBoxItem Content="10 minutes before"/>
+                                    <ComboBoxItem Content="15 minutes before"/>
+                                    <ComboBoxItem Content="30 minutes before"/>
                                 </ComboBox>
                             </Grid>
                         </Border>
@@ -181,14 +180,14 @@
 
                     <!-- ── System ── -->
                     <StackPanel x:Name="PanelSystem" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="系统" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="SystemHeaderText" Text="System" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="开机启动" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="登录 Windows 后自动启动应用。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Run on Startup" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Automatically launch the app when you sign in to Windows." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="RunOnStartupToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="False" Toggled="RunOnStartupToggle_Toggled"/>
@@ -199,8 +198,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="最小化到托盘" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="关闭窗口时隐藏到系统托盘而不是退出。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Minimize to Tray" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Hide the window to the system tray instead of closing." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="TrayIconToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="TrayIconToggle_Toggled"/>
@@ -211,8 +210,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="平滑滚动" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="在应用中启用惯性滚动效果。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Smooth Scrolling" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Enable inertia-based scrolling throughout the app." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="SmoothScrollingToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="False" Toggled="SmoothScrollingToggle_Toggled"/>
@@ -223,8 +222,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="显示隐藏任务" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="显示在 Windows 任务计划程序中被标记为隐藏的任务。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Show Hidden Tasks" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Display tasks that are marked as hidden in the Windows Task Scheduler." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="ShowHiddenTasksToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="ShowHiddenTasksToggle_Toggled"/>
@@ -234,14 +233,14 @@
 
                     <!-- ── Advanced ── -->
                     <StackPanel x:Name="PanelAdvanced" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="高级" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="AdvancedHeaderText" Text="Advanced" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="删除前确认" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="删除任务前弹出确认对话框。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Confirm Before Deleting" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Show a confirmation dialog before removing a task." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="ConfirmDeleteToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" Toggled="ConfirmDeleteToggle_Toggled"/>
@@ -252,8 +251,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="应用日志" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="将内部事件和错误写入日志文件，便于排查问题。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Application Logging" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Write internal events and errors to a log file for troubleshooting." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
                                     <ToggleSwitch x:Name="LoggingToggle" OffContent="" OnContent="" IsOn="True" Toggled="LoggingToggle_Toggled"/>
@@ -265,8 +264,8 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="分离日志文件" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="错误与崩溃日志单独存储，不写入主日志文件。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Separate Log Files" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Store error and crash logs in dedicated files instead of the main log." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <ToggleSwitch x:Name="SeparateLogsToggle" Grid.Column="1" VerticalAlignment="Center"
                                              OffContent="" OnContent="" IsOn="True" Toggled="SeparateLogsToggle_Toggled"/>
@@ -277,13 +276,13 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="专项日志" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="快速访问错误与崩溃日志。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Specific Logs" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Direct access to error and crash records." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-                                    <Button x:Name="OpenLogButton" Content="打开日志" Click="OpenLogButton_Click"/>
-                                    <Button x:Name="OpenErrorLogButton" Content="打开错误日志" Click="OpenErrorLogButton_Click"/>
-                                    <Button x:Name="OpenCrashLogButton" Content="打开崩溃日志" Click="OpenCrashLogButton_Click"/>
+                                    <Button x:Name="OpenLogButton" Content="Open Log" Click="OpenLogButton_Click"/>
+                                    <Button x:Name="OpenErrorLogButton" Content="Open Error Log" Click="OpenErrorLogButton_Click"/>
+                                    <Button x:Name="OpenCrashLogButton" Content="Open Crash Log" Click="OpenCrashLogButton_Click"/>
                                 </StackPanel>
                             </Grid>
                         </Border>
@@ -291,16 +290,16 @@
 
                     <!-- ── Data ── -->
                     <StackPanel x:Name="PanelData" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="数据" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="DataHeaderText" Text="Data" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="导出设置" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="将当前设置保存为 JSON 文件。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Export Settings" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Save your current settings to a JSON file." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
-                                <Button x:Name="ExportSettingsButton" Grid.Column="1" Content="导出" VerticalAlignment="Center" Click="ExportSettings_Click"/>
+                                <Button x:Name="ExportSettingsButton" Grid.Column="1" Content="Export" VerticalAlignment="Center" Click="ExportSettings_Click"/>
                             </Grid>
                         </Border>
 
@@ -308,30 +307,30 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="导入设置" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="从之前导出的文件恢复设置。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Import Settings" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Restore settings from a previously exported file." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
-                                <Button x:Name="ImportSettingsButton" Grid.Column="1" Content="导入" VerticalAlignment="Center" Click="ImportSettings_Click"/>
+                                <Button x:Name="ImportSettingsButton" Grid.Column="1" Content="Import" VerticalAlignment="Center" Click="ImportSettings_Click"/>
                             </Grid>
                         </Border>
                     </StackPanel>
 
                     <!-- ── Categories & Tags ── -->
                     <StackPanel x:Name="PanelCategories" Spacing="16" Visibility="Collapsed">
-                        <TextBlock Text="分类与标签" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="CategoriesHeaderText" Text="Categories &amp; Tags" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <!-- Categories Section -->
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <StackPanel Spacing="12">
-                                <TextBlock Text="管理分类" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                <TextBlock Text="为任务预设分类。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
+                                <TextBlock Text="Manage Categories" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="Predefined categories for your tasks." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox x:Name="NewCategoryBox" PlaceholderText="新分类名称..." KeyDown="NewCategoryBox_KeyDown"/>
-                                    <Button x:Name="AddCategoryBtn" Grid.Column="1" Content="添加" Click="AddCategory_Click"/>
+                                    <TextBox x:Name="NewCategoryBox" PlaceholderText="New category name..." KeyDown="NewCategoryBox_KeyDown"/>
+                                    <Button x:Name="AddCategoryBtn" Grid.Column="1" Content="Add" Click="AddCategory_Click"/>
                                 </Grid>
                                 <ItemsControl x:Name="CategoriesItemsControl">
                                     <ItemsControl.ItemsPanel>
@@ -360,15 +359,15 @@
                         <!-- Tags Section -->
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <StackPanel Spacing="12">
-                                <TextBlock Text="管理标签" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                <TextBlock Text="为任务预设标签。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
+                                <TextBlock Text="Manage Tags" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="Predefined tags for your tasks." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox x:Name="NewTagBox" PlaceholderText="新标签名称..." KeyDown="NewTagBox_KeyDown"/>
-                                    <Button x:Name="AddTagBtn" Grid.Column="1" Content="添加" Click="AddTag_Click"/>
+                                    <TextBox x:Name="NewTagBox" PlaceholderText="New tag name..." KeyDown="NewTagBox_KeyDown"/>
+                                    <Button x:Name="AddTagBtn" Grid.Column="1" Content="Add" Click="AddTag_Click"/>
                                 </Grid>
                                 <ItemsControl x:Name="TagsItemsControl">
                                     <ItemsControl.ItemsPanel>
@@ -397,18 +396,18 @@
 
                     <!-- ── About ── -->
                     <StackPanel x:Name="PanelAbout" Spacing="4" Visibility="Collapsed">
-                        <TextBlock Text="关于" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
+                        <TextBlock x:Name="AboutHeaderText" Text="About" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,12"/>
 
                         <Border Style="{StaticResource SettingsCardStyle}">
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center">
-                                     <TextBlock Text="Fluent Task Scheduler" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                     <TextBlock Text="基于 WinUI 3 · Windows App SDK 构建" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
+                                    <TextBlock Text="Fluent Task Scheduler" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Built with WinUI 3 · Windows App SDK" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6"/>
                                 </StackPanel>
                                 <Button x:Name="VersionButton" Grid.Column="1" Click="VersionButton_Click"
                                         Background="Transparent" BorderThickness="0" Padding="8,6"
-                                         VerticalAlignment="Center" ToolTipService.ToolTip="查看更新内容">
+                                        VerticalAlignment="Center" ToolTipService.ToolTip="See What's New">
                                     <StackPanel Orientation="Horizontal" Spacing="4">
                                         <TextBlock x:Uid="AboutVersion" Text="Version 1.8.1"
                                                    Style="{StaticResource CaptionTextBlockStyle}"
@@ -424,15 +423,15 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="检查更新" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="检查是否有可用的新版本。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Check for Updates" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Check if a newer version is available." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                                     <ProgressRing x:Name="UpdateCheckProgressRing" IsActive="False" Width="20" Height="20" Visibility="Collapsed"/>
                                     <Button x:Name="CheckForUpdatesButton" Click="CheckForUpdates_Click">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <FontIcon Glyph="&#xE895;" FontSize="13"/>
-                                            <TextBlock Text="检查"/>
+                                            <TextBlock Text="Check"/>
                                         </StackPanel>
                                     </Button>
                                 </StackPanel>
@@ -443,14 +442,14 @@
                             <Grid>
                                 <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
                                 <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
-                                    <TextBlock Text="新手引导" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                    <TextBlock Text="重新播放首次启动时的欢迎引导。" Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Onboarding" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="Replay the welcome walkthrough from first launch." Style="{StaticResource CaptionTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <Button x:Name="ReplayOnboardingButton" Grid.Column="1" VerticalAlignment="Center"
                                         Click="ReplayOnboardingButton_Click">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
                                         <FontIcon Glyph="&#xE7C3;" FontSize="13"/>
-                                        <TextBlock Text="再次查看"/>
+                                        <TextBlock Text="View Again"/>
                                     </StackPanel>
                                 </Button>
                             </Grid>

--- a/SettingsPage.xaml.cs
+++ b/SettingsPage.xaml.cs
@@ -15,6 +15,7 @@ namespace FluentTaskScheduler
         private StackPanel[]? _panels;
 
         private static readonly int[] _leadMinuteOptions = { 1, 5, 10, 15, 30 };
+        private static string L(string key, string fallback) => LocalizationService.GetString(key, fallback);
 
         public SettingsPage()
         {
@@ -33,6 +34,7 @@ namespace FluentTaskScheduler
                 ElementTheme.Dark => 1,
                 _ => 2
             };
+            LanguageComboBox.SelectedIndex = SettingsService.Language == "zh-CN" ? 1 : 0;
             OledModeToggle.IsOn = SettingsService.IsOledMode;
             MicaModeToggle.IsOn = SettingsService.IsMicaEnabled;
             UpdateOledToggleState();
@@ -116,6 +118,27 @@ namespace FluentTaskScheduler
             (Application.Current as App)?.ApplyTheme(SettingsService.Theme);
             UpdateOledToggleState();
             LogService.Info($"App Theme: {SettingsService.Theme}");
+        }
+
+        private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!_isLoaded) return;
+
+            string newLanguage = LanguageComboBox.SelectedIndex == 1 ? "zh-CN" : "en-US";
+            if (SettingsService.Language == newLanguage) return;
+
+            SettingsService.Language = newLanguage;
+            try
+            {
+                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = newLanguage;
+            }
+            catch
+            {
+            }
+
+            await ShowDialog(
+                L("Settings.Language.Changed.Title", "Language Updated"),
+                L("Settings.Language.Changed.Content", "Language preference has been saved. Restart the app to apply all text changes."));
         }
 
         private void MicaModeToggle_Toggled(object sender, RoutedEventArgs e)
@@ -268,12 +291,14 @@ namespace FluentTaskScheduler
                 if (file != null)
                 {
                     SettingsService.ExportSettings(file.Path);
-                    await ShowDialog("Export Successful", $"Settings exported to:\n{file.Path}");
+                    await ShowDialog(
+                        L("Settings.Export.Success.Title", "Export Successful"),
+                        string.Format(L("Settings.Export.Success.Content", "Settings exported to:\n{0}"), file.Path));
                 }
             }
             catch (Exception ex)
             {
-                await ShowDialog("Export Failed", ex.Message);
+                await ShowDialog(L("Settings.Export.Failed.Title", "Export Failed"), ex.Message);
             }
         }
 
@@ -300,12 +325,14 @@ namespace FluentTaskScheduler
                     TrayIconService.UpdateVisibility();
                     StartupService.UpdateFromSettings();
 
-                    await ShowDialog("Import Successful", "Settings have been restored. Some changes may require an app restart.");
+                    await ShowDialog(
+                        L("Settings.Import.Success.Title", "Import Successful"),
+                        L("Settings.Import.Success.Content", "Settings have been restored. Some changes may require an app restart."));
                 }
             }
             catch (Exception ex)
             {
-                await ShowDialog("Import Failed", ex.Message);
+                await ShowDialog(L("Settings.Import.Failed.Title", "Import Failed"), ex.Message);
             }
         }
 
@@ -316,7 +343,9 @@ namespace FluentTaskScheduler
             var release = await Services.GitHubReleaseService.GetLatestReleaseAsync();
             if (release == null)
             {
-                await ShowDialog("What's New", "Could not fetch release notes. Check your internet connection and try again.");
+                await ShowDialog(
+                    L("Settings.WhatsNew.Title", "What's New"),
+                    L("Settings.WhatsNew.FetchFailed", "Could not fetch release notes. Check your internet connection and try again."));
                 return;
             }
             var dialog = new Dialogs.WhatsNewDialog(release) { XamlRoot = this.XamlRoot };
@@ -337,22 +366,28 @@ namespace FluentTaskScheduler
 
             if (result.Status == Services.VeloPackUpdateService.UpdateResultStatus.Error)
             {
-                await ShowDialog("Update Error", $"An error occurred while checking for updates:\n{result.ErrorMessage}");
+                await ShowDialog(
+                    L("Settings.Update.ErrorTitle", "Update Error"),
+                    string.Format(L("Settings.Update.ErrorContent", "An error occurred while checking for updates:\n{0}"), result.ErrorMessage));
                 return;
             }
 
             if (result.Status == Services.VeloPackUpdateService.UpdateResultStatus.NoUpdate || result.Info == null)
             {
-                await ShowDialog("Up to Date", "You're already running the latest version.");
+                await ShowDialog(
+                    L("Settings.Update.UpToDate.Title", "Up to Date"),
+                    L("Settings.Update.UpToDate.Content", "You're already running the latest version."));
                 return;
             }
 
             var dialog = new ContentDialog
             {
-                Title = "Update Available",
-                Content = $"Version {result.NewVersion} has been downloaded and is ready to install.\nRestart now to apply the update?",
-                PrimaryButtonText = "Restart Now",
-                CloseButtonText = "Later",
+                Title = L("Settings.Update.Available.Title", "Update Available"),
+                Content = string.Format(
+                    L("Settings.Update.Available.Content", "Version {0} has been downloaded and is ready to install.\nRestart now to apply the update?"),
+                    result.NewVersion),
+                PrimaryButtonText = L("Dialog.RestartNow", "Restart Now"),
+                CloseButtonText = L("Dialog.Later", "Later"),
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = SettingsService.Theme
             };
@@ -377,7 +412,7 @@ namespace FluentTaskScheduler
             {
                 Title = title,
                 Content = message,
-                CloseButtonText = "OK",
+                CloseButtonText = L("Dialog.OK", "OK"),
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = SettingsService.Theme
             };

--- a/SettingsPage.xaml.cs
+++ b/SettingsPage.xaml.cs
@@ -6,6 +6,7 @@ using FluentTaskScheduler.Services;
 using Windows.Storage.Pickers;
 using Microsoft.UI.Xaml.Input;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace FluentTaskScheduler
 {
@@ -13,14 +14,31 @@ namespace FluentTaskScheduler
     {
         private bool _isLoaded = false;
         private StackPanel[]? _panels;
+        private readonly Dictionary<string, string> _sectionTitles = new();
 
         private static readonly int[] _leadMinuteOptions = { 1, 5, 10, 15, 30 };
-        private static string L(string key, string fallback) => LocalizationService.GetString(key, fallback);
 
         public SettingsPage()
         {
             this.InitializeComponent();
             Loaded += SettingsPage_Loaded;
+            LocalizationService.LanguageChanged += LocalizationService_LanguageChanged;
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            LocalizationService.LanguageChanged -= LocalizationService_LanguageChanged;
+            base.OnNavigatedFrom(e);
+        }
+
+        private void LocalizationService_LanguageChanged(object? sender, EventArgs e)
+        {
+            if (DispatcherQueue == null) return;
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                ApplyLocalizedUi();
+                SyncPanelVisibility();
+            });
         }
 
         private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
@@ -34,9 +52,9 @@ namespace FluentTaskScheduler
                 ElementTheme.Dark => 1,
                 _ => 2
             };
-            LanguageComboBox.SelectedIndex = SettingsService.Language == "zh-CN" ? 1 : 0;
             OledModeToggle.IsOn = SettingsService.IsOledMode;
             MicaModeToggle.IsOn = SettingsService.IsMicaEnabled;
+            LanguageComboBox.SelectedIndex = SettingsService.Language == "zh-CN" ? 1 : 0;
             UpdateOledToggleState();
 
             // Notifications
@@ -71,6 +89,8 @@ namespace FluentTaskScheduler
             _isLoaded = true;
             PageScrollViewer.IsScrollInertiaEnabled = SettingsService.SmoothScrolling;
 
+            ApplyLocalizedUi();
+
         }
 
         // ── Sidebar ────────────────────────────────────────────────────────────
@@ -90,6 +110,11 @@ namespace FluentTaskScheduler
             if (selectedItem == null) return;
 
             string tag = selectedItem.Tag?.ToString() ?? "";
+
+            if (_sectionTitles.TryGetValue(tag, out var title))
+            {
+                SettingsNav.Header = title;
+            }
             
             PanelAppearance.Visibility = tag == "Appearance" ? Visibility.Visible : Visibility.Collapsed;
             PanelNotifications.Visibility = tag == "Notifications" ? Visibility.Visible : Visibility.Collapsed;
@@ -120,27 +145,6 @@ namespace FluentTaskScheduler
             LogService.Info($"App Theme: {SettingsService.Theme}");
         }
 
-        private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (!_isLoaded) return;
-
-            string newLanguage = LanguageComboBox.SelectedIndex == 1 ? "zh-CN" : "en-US";
-            if (SettingsService.Language == newLanguage) return;
-
-            SettingsService.Language = newLanguage;
-            try
-            {
-                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = newLanguage;
-            }
-            catch
-            {
-            }
-
-            await ShowDialog(
-                L("Settings.Language.Changed.Title", "Language Updated"),
-                L("Settings.Language.Changed.Content", "Language preference has been saved. Restart the app to apply all text changes."));
-        }
-
         private void MicaModeToggle_Toggled(object sender, RoutedEventArgs e)
         {
             if (!_isLoaded) return;
@@ -163,6 +167,50 @@ namespace FluentTaskScheduler
             bool isDark = SettingsService.Theme == ElementTheme.Dark;
             OledModeToggle.IsEnabled = isDark;
             MicaModeToggle.IsEnabled = !isDark || !SettingsService.IsOledMode;
+        }
+
+        private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            if (LanguageComboBox.SelectedItem is not ComboBoxItem selected) return;
+
+            string language = selected.Tag?.ToString() ?? "en-US";
+            bool changed = LocalizationService.ChangeLanguage(language);
+            if (changed)
+            {
+                LogService.Info($"Language switched to {language}");
+            }
+        }
+
+        private void ApplyLocalizedUi()
+        {
+            string L(string key, string fallback) => LocalizationService.GetString(key, fallback);
+
+            NavAppearanceItem.Content = L("Settings.Nav.Appearance", "Appearance");
+            NavNotificationsItem.Content = L("Settings.Nav.Notifications", "Notifications");
+            NavSystemItem.Content = L("Settings.Nav.System", "System");
+            NavAdvancedItem.Content = L("Settings.Nav.Advanced", "Advanced");
+            NavDataItem.Content = L("Settings.Nav.Data", "Data");
+            NavCategoriesItem.Content = L("Settings.Nav.Categories", "Categories & Tags");
+            NavAboutItem.Content = L("Settings.Nav.About", "About");
+
+            AppearanceHeaderText.Text = L("Settings.Section.Appearance", "Appearance");
+            NotificationsHeaderText.Text = L("Settings.Section.Notifications", "Notifications");
+            SystemHeaderText.Text = L("Settings.Section.System", "System");
+            AdvancedHeaderText.Text = L("Settings.Section.Advanced", "Advanced");
+            DataHeaderText.Text = L("Settings.Section.Data", "Data");
+            CategoriesHeaderText.Text = L("Settings.Section.Categories", "Categories & Tags");
+            AboutHeaderText.Text = L("Settings.Section.About", "About");
+            LanguageTitleText.Text = L("Settings.Appearance.Language.Title", "Language");
+            LanguageDescriptionText.Text = L("Settings.Appearance.Language.Description", "Choose the display language for the app.");
+
+            _sectionTitles["Appearance"] = L("Settings.Section.Appearance", "Appearance");
+            _sectionTitles["Notifications"] = L("Settings.Section.Notifications", "Notifications");
+            _sectionTitles["System"] = L("Settings.Section.System", "System");
+            _sectionTitles["Advanced"] = L("Settings.Section.Advanced", "Advanced");
+            _sectionTitles["Data"] = L("Settings.Section.Data", "Data");
+            _sectionTitles["Categories"] = L("Settings.Section.Categories", "Categories & Tags");
+            _sectionTitles["About"] = L("Settings.Section.About", "About");
         }
 
         // ── Notifications ──────────────────────────────────────────────────────
@@ -292,13 +340,13 @@ namespace FluentTaskScheduler
                 {
                     SettingsService.ExportSettings(file.Path);
                     await ShowDialog(
-                        L("Settings.Export.Success.Title", "Export Successful"),
-                        string.Format(L("Settings.Export.Success.Content", "Settings exported to:\n{0}"), file.Path));
+                        LocalizationService.GetString("Settings.Export.Success.Title", "Export Successful"),
+                        string.Format(LocalizationService.GetString("Settings.Export.Success.ContentFormat", "Settings exported to:\n{0}"), file.Path));
                 }
             }
             catch (Exception ex)
             {
-                await ShowDialog(L("Settings.Export.Failed.Title", "Export Failed"), ex.Message);
+                await ShowDialog(LocalizationService.GetString("Settings.Export.Failed.Title", "Export Failed"), ex.Message);
             }
         }
 
@@ -326,13 +374,13 @@ namespace FluentTaskScheduler
                     StartupService.UpdateFromSettings();
 
                     await ShowDialog(
-                        L("Settings.Import.Success.Title", "Import Successful"),
-                        L("Settings.Import.Success.Content", "Settings have been restored. Some changes may require an app restart."));
+                        LocalizationService.GetString("Settings.Import.Success.Title", "Import Successful"),
+                        LocalizationService.GetString("Settings.Import.Success.Content", "Settings have been restored. Some changes may require an app restart."));
                 }
             }
             catch (Exception ex)
             {
-                await ShowDialog(L("Settings.Import.Failed.Title", "Import Failed"), ex.Message);
+                await ShowDialog(LocalizationService.GetString("Settings.Import.Failed.Title", "Import Failed"), ex.Message);
             }
         }
 
@@ -344,8 +392,8 @@ namespace FluentTaskScheduler
             if (release == null)
             {
                 await ShowDialog(
-                    L("Settings.WhatsNew.Title", "What's New"),
-                    L("Settings.WhatsNew.FetchFailed", "Could not fetch release notes. Check your internet connection and try again."));
+                    LocalizationService.GetString("Settings.WhatsNew.Title", "What's New"),
+                    LocalizationService.GetString("Settings.WhatsNew.FetchFailed", "Could not fetch release notes. Check your internet connection and try again."));
                 return;
             }
             var dialog = new Dialogs.WhatsNewDialog(release) { XamlRoot = this.XamlRoot };
@@ -367,27 +415,27 @@ namespace FluentTaskScheduler
             if (result.Status == Services.VeloPackUpdateService.UpdateResultStatus.Error)
             {
                 await ShowDialog(
-                    L("Settings.Update.ErrorTitle", "Update Error"),
-                    string.Format(L("Settings.Update.ErrorContent", "An error occurred while checking for updates:\n{0}"), result.ErrorMessage));
+                    LocalizationService.GetString("Settings.UpdateError.Title", "Update Error"),
+                    string.Format(LocalizationService.GetString("Settings.UpdateError.ContentFormat", "An error occurred while checking for updates:\n{0}"), result.ErrorMessage));
                 return;
             }
 
             if (result.Status == Services.VeloPackUpdateService.UpdateResultStatus.NoUpdate || result.Info == null)
             {
                 await ShowDialog(
-                    L("Settings.Update.UpToDate.Title", "Up to Date"),
-                    L("Settings.Update.UpToDate.Content", "You're already running the latest version."));
+                    LocalizationService.GetString("Settings.UpToDate.Title", "Up to Date"),
+                    LocalizationService.GetString("Settings.UpToDate.Content", "You're already running the latest version."));
                 return;
             }
 
             var dialog = new ContentDialog
             {
-                Title = L("Settings.Update.Available.Title", "Update Available"),
+                Title = LocalizationService.GetString("Dialog.UpdateAvailable.Title", "Update Available"),
                 Content = string.Format(
-                    L("Settings.Update.Available.Content", "Version {0} has been downloaded and is ready to install.\nRestart now to apply the update?"),
+                    LocalizationService.GetString("Dialog.UpdateAvailable.ContentFormat", "Version {0} has been downloaded and is ready to install.\nRestart now to apply the update?"),
                     result.NewVersion),
-                PrimaryButtonText = L("Dialog.RestartNow", "Restart Now"),
-                CloseButtonText = L("Dialog.Later", "Later"),
+                PrimaryButtonText = LocalizationService.GetString("Dialog.UpdateAvailable.RestartNow", "Restart Now"),
+                CloseButtonText = LocalizationService.GetString("Dialog.Common.Later", "Later"),
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = SettingsService.Theme
             };
@@ -412,7 +460,7 @@ namespace FluentTaskScheduler
             {
                 Title = title,
                 Content = message,
-                CloseButtonText = L("Dialog.OK", "OK"),
+                CloseButtonText = LocalizationService.GetString("Dialog.Common.OK", "OK"),
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = SettingsService.Theme
             };

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -118,4 +118,94 @@
   <data name="AboutHeader.Text" xml:space="preserve"><value>About</value></data>
   <data name="AboutTitle.Text" xml:space="preserve"><value>Fluent Task Scheduler</value></data>
   <data name="AboutBuilt.Text" xml:space="preserve"><value>Built with WinUI 3</value></data>
+  <data name="Dialog.Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Dialog.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Dialog.OK" xml:space="preserve"><value>OK</value></data>
+  <data name="Dialog.Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="Dialog.Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Dialog.Create" xml:space="preserve"><value>Create</value></data>
+  <data name="Dialog.Rename" xml:space="preserve"><value>Rename</value></data>
+  <data name="Dialog.RestartNow" xml:space="preserve"><value>Restart Now</value></data>
+  <data name="Dialog.Later" xml:space="preserve"><value>Later</value></data>
+  <data name="Dialog.Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Dialog.GetStarted" xml:space="preserve"><value>Get Started</value></data>
+  <data name="App.UnhandledException.Title" xml:space="preserve"><value>Unhandled Exception</value></data>
+  <data name="App.UpdateAvailable.Title" xml:space="preserve"><value>Update Available</value></data>
+  <data name="App.UpdateAvailable.Content" xml:space="preserve"><value>Version {0} has been downloaded and is ready to install.
+Restart now to apply the update?</value></data>
+  <data name="Main.HistoryCopied" xml:space="preserve"><value>✅ Copied!</value></data>
+  <data name="Main.HistoryCopy" xml:space="preserve"><value>📋 Copy</value></data>
+  <data name="Main.ConfirmDelete.Title" xml:space="preserve"><value>Confirm Delete</value></data>
+  <data name="Main.ConfirmDelete.Content" xml:space="preserve"><value>Are you sure you want to delete '{0}'?</value></data>
+  <data name="Main.ImportTask.Title" xml:space="preserve"><value>Import Task</value></data>
+  <data name="Main.ImportTask.SelectFolder" xml:space="preserve"><value>Select the folder to import this task into:</value></data>
+  <data name="Main.AnyNetwork" xml:space="preserve"><value>Any network</value></data>
+  <data name="Main.PermissionEnableDenied" xml:space="preserve"><value>The user account under which you are performing this action does not have permission to enable the following task(s):
+
+{0}
+
+These tasks are protected and cannot be modified, even with administrator privileges.</value></data>
+  <data name="Main.PermissionDisableDenied" xml:space="preserve"><value>The user account under which you are performing this action does not have permission to disable the following task(s):
+
+{0}
+
+These tasks are protected and cannot be modified, even with administrator privileges.</value></data>
+  <data name="Main.BatchDelete.Content" xml:space="preserve"><value>Delete {0} tasks?</value></data>
+  <data name="Main.NewFolder.Title" xml:space="preserve"><value>New Folder</value></data>
+  <data name="Main.NewFolder.NamePlaceholder" xml:space="preserve"><value>Name</value></data>
+  <data name="Main.RenameFolder.Title" xml:space="preserve"><value>Rename Folder</value></data>
+  <data name="Main.RenameFolder.NamePlaceholder" xml:space="preserve"><value>New Name</value></data>
+  <data name="Main.DeleteFolder.Title" xml:space="preserve"><value>Delete Folder</value></data>
+  <data name="Main.DeleteFolder.Content" xml:space="preserve"><value>Delete '{0}' and ALL tasks in it?</value></data>
+  <data name="Main.MoveTasksPartialError" xml:space="preserve"><value>Some tasks could not be moved:
+
+</value></data>
+  <data name="Main.MoveFolderError" xml:space="preserve"><value>Could not move folder: {0}</value></data>
+  <data name="Main.Error.Title" xml:space="preserve"><value>Error</value></data>
+  <data name="ScriptLibrary.DeleteTemplate.Title" xml:space="preserve"><value>Delete Template</value></data>
+  <data name="ScriptLibrary.DeleteTemplate.Content" xml:space="preserve"><value>Delete '{0}'?</value></data>
+  <data name="SettingsLanguageTitle.Text" xml:space="preserve"><value>Language</value></data>
+  <data name="SettingsLanguageHint.Text" xml:space="preserve"><value>Select UI language. Restart the app to apply all text changes.</value></data>
+  <data name="SettingsLanguageEnglish.Content" xml:space="preserve"><value>English</value></data>
+  <data name="SettingsLanguageChinese.Content" xml:space="preserve"><value>Simplified Chinese</value></data>
+  <data name="Settings.Language.Changed.Title" xml:space="preserve"><value>Language Updated</value></data>
+  <data name="Settings.Language.Changed.Content" xml:space="preserve"><value>Language preference has been saved. Restart the app to apply all text changes.</value></data>
+  <data name="Settings.Export.Success.Title" xml:space="preserve"><value>Export Successful</value></data>
+  <data name="Settings.Export.Success.Content" xml:space="preserve"><value>Settings exported to:
+{0}</value></data>
+  <data name="Settings.Export.Failed.Title" xml:space="preserve"><value>Export Failed</value></data>
+  <data name="Settings.Import.Success.Title" xml:space="preserve"><value>Import Successful</value></data>
+  <data name="Settings.Import.Success.Content" xml:space="preserve"><value>Settings have been restored. Some changes may require an app restart.</value></data>
+  <data name="Settings.Import.Failed.Title" xml:space="preserve"><value>Import Failed</value></data>
+  <data name="Settings.WhatsNew.Title" xml:space="preserve"><value>What's New</value></data>
+  <data name="Settings.WhatsNew.FetchFailed" xml:space="preserve"><value>Could not fetch release notes. Check your internet connection and try again.</value></data>
+  <data name="Settings.Update.ErrorTitle" xml:space="preserve"><value>Update Error</value></data>
+  <data name="Settings.Update.ErrorContent" xml:space="preserve"><value>An error occurred while checking for updates:
+{0}</value></data>
+  <data name="Settings.Update.UpToDate.Title" xml:space="preserve"><value>Up to Date</value></data>
+  <data name="Settings.Update.UpToDate.Content" xml:space="preserve"><value>You're already running the latest version.</value></data>
+  <data name="Settings.Update.Available.Title" xml:space="preserve"><value>Update Available</value></data>
+  <data name="Settings.Update.Available.Content" xml:space="preserve"><value>Version {0} has been downloaded and is ready to install.
+Restart now to apply the update?</value></data>
+  <data name="OnboardingHint.Text" xml:space="preserve"><value>You can replay this walkthrough anytime from Settings.</value></data>
+  <data name="OnboardingWarn.Text" xml:space="preserve"><value>Some tasks are discovered via the Event Log and can thus not be edited.
+Run as admin if you want to edit them.</value></data>
+  <data name="OnboardingBackButton.Content" xml:space="preserve"><value>Back</value></data>
+  <data name="OnboardingNextButton.Content" xml:space="preserve"><value>Next</value></data>
+  <data name="Onboarding.Step1.Title" xml:space="preserve"><value>Welcome to FluentTaskScheduler</value></data>
+  <data name="Onboarding.Step1.Body" xml:space="preserve"><value>Manage Windows Task Scheduler with a modern, fluent interface — no XML, no fuss.</value></data>
+  <data name="Onboarding.Step2.Title" xml:space="preserve"><value>Create your first task</value></data>
+  <data name="Onboarding.Step2.Body" xml:space="preserve"><value>Hit + New Task to schedule any program, script, or command to run automatically — daily, on login, on an event, and more.</value></data>
+  <data name="Onboarding.Step3.Title" xml:space="preserve"><value>Organise with folders</value></data>
+  <data name="Onboarding.Step3.Body" xml:space="preserve"><value>Group related tasks into folders using the sidebar, just like Windows Explorer. Your last folder is remembered across restarts.</value></data>
+  <data name="Onboarding.Step4.Title" xml:space="preserve"><value>Track history &amp; status</value></data>
+  <data name="Onboarding.Step4.Body" xml:space="preserve"><value>Click any task to see its run history, success and failure counts, and live running status — all in one place.</value></data>
+  <data name="Onboarding.Step5.Title" xml:space="preserve"><value>Always up to date</value></data>
+  <data name="Onboarding.Step5.Body" xml:space="preserve"><value>FluentTaskScheduler checks for updates automatically every time it starts. You can also trigger a manual check at any time from Settings → About → Check for Updates.</value></data>
+  <data name="Onboarding.Step6.Title" xml:space="preserve"><value>Discover existing tasks</value></data>
+  <data name="Onboarding.Step6.Body" xml:space="preserve"><value>Use Task Discovery to scan the Windows Event Log and automatically import tasks created by other applications — no manual recreation needed.</value></data>
+  <data name="Onboarding.Step7.Title" xml:space="preserve"><value>Tune it to your liking</value></data>
+  <data name="Onboarding.Step7.Body" xml:space="preserve"><value>Head to Settings to enable Mica backdrop, minimise to tray, configure logging, run on startup, and more.</value></data>
+  <data name="WhatsNewDialog.CloseButtonText" xml:space="preserve"><value>Got it</value></data>
+  <data name="WhatsNewViewOnGitHub.Text" xml:space="preserve"><value>View full release on GitHub</value></data>
 </root>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -118,60 +118,85 @@
   <data name="AboutHeader.Text" xml:space="preserve"><value>About</value></data>
   <data name="AboutTitle.Text" xml:space="preserve"><value>Fluent Task Scheduler</value></data>
   <data name="AboutBuilt.Text" xml:space="preserve"><value>Built with WinUI 3</value></data>
-  <data name="Dialog.Close" xml:space="preserve"><value>Close</value></data>
-  <data name="Dialog.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="Dialog.OK" xml:space="preserve"><value>OK</value></data>
-  <data name="Dialog.Delete" xml:space="preserve"><value>Delete</value></data>
-  <data name="Dialog.Import" xml:space="preserve"><value>Import</value></data>
-  <data name="Dialog.Create" xml:space="preserve"><value>Create</value></data>
-  <data name="Dialog.Rename" xml:space="preserve"><value>Rename</value></data>
-  <data name="Dialog.RestartNow" xml:space="preserve"><value>Restart Now</value></data>
-  <data name="Dialog.Later" xml:space="preserve"><value>Later</value></data>
-  <data name="Dialog.Next" xml:space="preserve"><value>Next</value></data>
-  <data name="Dialog.GetStarted" xml:space="preserve"><value>Get Started</value></data>
-  <data name="App.UnhandledException.Title" xml:space="preserve"><value>Unhandled Exception</value></data>
-  <data name="App.UpdateAvailable.Title" xml:space="preserve"><value>Update Available</value></data>
-  <data name="App.UpdateAvailable.Content" xml:space="preserve"><value>Version {0} has been downloaded and is ready to install.
+  <data name="App.WindowTitle" xml:space="preserve"><value>FluentTaskScheduler</value></data>
+  <data name="Dialog.Common.OK" xml:space="preserve"><value>OK</value></data>
+  <data name="Dialog.Common.Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Dialog.Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Dialog.Common.Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="Dialog.Common.Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Dialog.Common.Create" xml:space="preserve"><value>Create</value></data>
+  <data name="Dialog.Common.Rename" xml:space="preserve"><value>Rename</value></data>
+  <data name="Dialog.Common.Later" xml:space="preserve"><value>Later</value></data>
+  <data name="Dialog.Common.Save" xml:space="preserve"><value>Save</value></data>
+  <data name="Dialog.Error.Title" xml:space="preserve"><value>Error</value></data>
+  <data name="Dialog.ConfirmDelete.Title" xml:space="preserve"><value>Confirm Delete</value></data>
+  <data name="Dialog.DeleteTask.ContentFormat" xml:space="preserve"><value>Are you sure you want to delete '{0}'?</value></data>
+  <data name="Dialog.BatchDelete.ContentFormat" xml:space="preserve"><value>Delete {0} tasks?</value></data>
+  <data name="Dialog.ImportTask.Title" xml:space="preserve"><value>Import Task</value></data>
+  <data name="Dialog.ImportTask.SelectFolder" xml:space="preserve"><value>Select the folder to import this task into:</value></data>
+  <data name="Dialog.NewFolder.Title" xml:space="preserve"><value>New Folder</value></data>
+  <data name="Dialog.NewFolder.NamePlaceholder" xml:space="preserve"><value>Name</value></data>
+  <data name="Dialog.RenameFolder.Title" xml:space="preserve"><value>Rename Folder</value></data>
+  <data name="Dialog.RenameFolder.NewNamePlaceholder" xml:space="preserve"><value>New Name</value></data>
+  <data name="Dialog.DeleteFolder.Title" xml:space="preserve"><value>Delete Folder</value></data>
+  <data name="Dialog.DeleteFolder.ContentFormat" xml:space="preserve"><value>Delete '{0}' and ALL tasks in it?</value></data>
+  <data name="Dialog.UpdateAvailable.Title" xml:space="preserve"><value>Update Available</value></data>
+  <data name="Dialog.UpdateAvailable.ContentFormat" xml:space="preserve"><value>Version {0} has been downloaded and is ready to install.
 Restart now to apply the update?</value></data>
-  <data name="Main.HistoryCopied" xml:space="preserve"><value>✅ Copied!</value></data>
-  <data name="Main.HistoryCopy" xml:space="preserve"><value>📋 Copy</value></data>
-  <data name="Main.ConfirmDelete.Title" xml:space="preserve"><value>Confirm Delete</value></data>
-  <data name="Main.ConfirmDelete.Content" xml:space="preserve"><value>Are you sure you want to delete '{0}'?</value></data>
-  <data name="Main.ImportTask.Title" xml:space="preserve"><value>Import Task</value></data>
-  <data name="Main.ImportTask.SelectFolder" xml:space="preserve"><value>Select the folder to import this task into:</value></data>
-  <data name="Main.AnyNetwork" xml:space="preserve"><value>Any network</value></data>
-  <data name="Main.PermissionEnableDenied" xml:space="preserve"><value>The user account under which you are performing this action does not have permission to enable the following task(s):
-
-{0}
-
-These tasks are protected and cannot be modified, even with administrator privileges.</value></data>
-  <data name="Main.PermissionDisableDenied" xml:space="preserve"><value>The user account under which you are performing this action does not have permission to disable the following task(s):
-
-{0}
-
-These tasks are protected and cannot be modified, even with administrator privileges.</value></data>
-  <data name="Main.BatchDelete.Content" xml:space="preserve"><value>Delete {0} tasks?</value></data>
-  <data name="Main.NewFolder.Title" xml:space="preserve"><value>New Folder</value></data>
-  <data name="Main.NewFolder.NamePlaceholder" xml:space="preserve"><value>Name</value></data>
-  <data name="Main.RenameFolder.Title" xml:space="preserve"><value>Rename Folder</value></data>
-  <data name="Main.RenameFolder.NamePlaceholder" xml:space="preserve"><value>New Name</value></data>
-  <data name="Main.DeleteFolder.Title" xml:space="preserve"><value>Delete Folder</value></data>
-  <data name="Main.DeleteFolder.Content" xml:space="preserve"><value>Delete '{0}' and ALL tasks in it?</value></data>
-  <data name="Main.MoveTasksPartialError" xml:space="preserve"><value>Some tasks could not be moved:
-
-</value></data>
-  <data name="Main.MoveFolderError" xml:space="preserve"><value>Could not move folder: {0}</value></data>
-  <data name="Main.Error.Title" xml:space="preserve"><value>Error</value></data>
-  <data name="ScriptLibrary.DeleteTemplate.Title" xml:space="preserve"><value>Delete Template</value></data>
-  <data name="ScriptLibrary.DeleteTemplate.Content" xml:space="preserve"><value>Delete '{0}'?</value></data>
-  <data name="SettingsLanguageTitle.Text" xml:space="preserve"><value>Language</value></data>
-  <data name="SettingsLanguageHint.Text" xml:space="preserve"><value>Select UI language. Restart the app to apply all text changes.</value></data>
-  <data name="SettingsLanguageEnglish.Content" xml:space="preserve"><value>English</value></data>
-  <data name="SettingsLanguageChinese.Content" xml:space="preserve"><value>Simplified Chinese</value></data>
-  <data name="Settings.Language.Changed.Title" xml:space="preserve"><value>Language Updated</value></data>
-  <data name="Settings.Language.Changed.Content" xml:space="preserve"><value>Language preference has been saved. Restart the app to apply all text changes.</value></data>
+  <data name="Dialog.UpdateAvailable.RestartNow" xml:space="preserve"><value>Restart Now</value></data>
+  <data name="Main.Nav.Dashboard" xml:space="preserve"><value>Dashboard</value></data>
+  <data name="Main.Nav.ScriptLibrary" xml:space="preserve"><value>Script Library</value></data>
+  <data name="Main.Nav.NewTask" xml:space="preserve"><value>New Task</value></data>
+  <data name="Main.Nav.AllTasks" xml:space="preserve"><value>All Tasks</value></data>
+  <data name="Main.Nav.Running" xml:space="preserve"><value>Running</value></data>
+  <data name="Main.Nav.Enabled" xml:space="preserve"><value>Enabled</value></data>
+  <data name="Main.Nav.Disabled" xml:space="preserve"><value>Disabled</value></data>
+  <data name="Main.Nav.Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Main.Header.ScheduledTasks" xml:space="preserve"><value>Scheduled Tasks</value></data>
+  <data name="Main.Header.Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Main.Header.Dashboard" xml:space="preserve"><value>Dashboard</value></data>
+  <data name="Main.Header.ScriptLibrary" xml:space="preserve"><value>Script Library</value></data>
+  <data name="Main.Toolbar.ImportTask" xml:space="preserve"><value>Import Task</value></data>
+  <data name="Main.Toolbar.Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="Main.Toolbar.ShortcutsButton" xml:space="preserve"><value>?</value></data>
+  <data name="Main.Toolbar.ShortcutsTooltip" xml:space="preserve"><value>Keyboard Shortcuts (F1)</value></data>
+  <data name="Main.Toolbar.SortButton" xml:space="preserve"><value>Sort ↕</value></data>
+  <data name="Main.Toolbar.SortActiveFormat" xml:space="preserve"><value>Sort {0} {1}</value></data>
+  <data name="Main.Sort.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Main.Sort.Status" xml:space="preserve"><value>Status</value></data>
+  <data name="Main.Sort.NextRun" xml:space="preserve"><value>Next Run</value></data>
+  <data name="Main.Sort.LastRun" xml:space="preserve"><value>Last Run</value></data>
+  <data name="Main.Sort.Clear" xml:space="preserve"><value>Clear Sort</value></data>
+  <data name="Main.Task.RunNow" xml:space="preserve"><value>Run Now</value></data>
+  <data name="Main.Task.Stop" xml:space="preserve"><value>Stop</value></data>
+  <data name="Main.Task.Edit" xml:space="preserve"><value>Edit</value></data>
+  <data name="Main.Task.Export" xml:space="preserve"><value>Export</value></data>
+  <data name="Main.Task.Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="Main.HistoryDialog.Title" xml:space="preserve"><value>Task History</value></data>
+  <data name="Main.History.Copy" xml:space="preserve"><value>📋 Copy</value></data>
+  <data name="Main.History.Copied" xml:space="preserve"><value>✅ Copied!</value></data>
+  <data name="Main.ShortcutsDialog.Title" xml:space="preserve"><value>Keyboard Shortcuts</value></data>
+  <data name="Main.AdminDragWarning.Title" xml:space="preserve"><value>Drag &amp; Drop Restricted</value></data>
+  <data name="Main.AdminDragWarning.Message" xml:space="preserve"><value>Windows does not support drag-and-drop operations when the app is running as Administrator.</value></data>
+  <data name="Main.Network.Any" xml:space="preserve"><value>Any network</value></data>
+  <data name="Settings.Nav.Appearance" xml:space="preserve"><value>Appearance</value></data>
+  <data name="Settings.Nav.Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings.Nav.System" xml:space="preserve"><value>System</value></data>
+  <data name="Settings.Nav.Advanced" xml:space="preserve"><value>Advanced</value></data>
+  <data name="Settings.Nav.Data" xml:space="preserve"><value>Data</value></data>
+  <data name="Settings.Nav.Categories" xml:space="preserve"><value>Categories &amp; Tags</value></data>
+  <data name="Settings.Nav.About" xml:space="preserve"><value>About</value></data>
+  <data name="Settings.Section.Appearance" xml:space="preserve"><value>Appearance</value></data>
+  <data name="Settings.Section.Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings.Section.System" xml:space="preserve"><value>System</value></data>
+  <data name="Settings.Section.Advanced" xml:space="preserve"><value>Advanced</value></data>
+  <data name="Settings.Section.Data" xml:space="preserve"><value>Data</value></data>
+  <data name="Settings.Section.Categories" xml:space="preserve"><value>Categories &amp; Tags</value></data>
+  <data name="Settings.Section.About" xml:space="preserve"><value>About</value></data>
+  <data name="Settings.Appearance.Language.Title" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings.Appearance.Language.Description" xml:space="preserve"><value>Choose the display language for the app.</value></data>
   <data name="Settings.Export.Success.Title" xml:space="preserve"><value>Export Successful</value></data>
-  <data name="Settings.Export.Success.Content" xml:space="preserve"><value>Settings exported to:
+  <data name="Settings.Export.Success.ContentFormat" xml:space="preserve"><value>Settings exported to:
 {0}</value></data>
   <data name="Settings.Export.Failed.Title" xml:space="preserve"><value>Export Failed</value></data>
   <data name="Settings.Import.Success.Title" xml:space="preserve"><value>Import Successful</value></data>
@@ -179,33 +204,9 @@ These tasks are protected and cannot be modified, even with administrator privil
   <data name="Settings.Import.Failed.Title" xml:space="preserve"><value>Import Failed</value></data>
   <data name="Settings.WhatsNew.Title" xml:space="preserve"><value>What's New</value></data>
   <data name="Settings.WhatsNew.FetchFailed" xml:space="preserve"><value>Could not fetch release notes. Check your internet connection and try again.</value></data>
-  <data name="Settings.Update.ErrorTitle" xml:space="preserve"><value>Update Error</value></data>
-  <data name="Settings.Update.ErrorContent" xml:space="preserve"><value>An error occurred while checking for updates:
+  <data name="Settings.UpdateError.Title" xml:space="preserve"><value>Update Error</value></data>
+  <data name="Settings.UpdateError.ContentFormat" xml:space="preserve"><value>An error occurred while checking for updates:
 {0}</value></data>
-  <data name="Settings.Update.UpToDate.Title" xml:space="preserve"><value>Up to Date</value></data>
-  <data name="Settings.Update.UpToDate.Content" xml:space="preserve"><value>You're already running the latest version.</value></data>
-  <data name="Settings.Update.Available.Title" xml:space="preserve"><value>Update Available</value></data>
-  <data name="Settings.Update.Available.Content" xml:space="preserve"><value>Version {0} has been downloaded and is ready to install.
-Restart now to apply the update?</value></data>
-  <data name="OnboardingHint.Text" xml:space="preserve"><value>You can replay this walkthrough anytime from Settings.</value></data>
-  <data name="OnboardingWarn.Text" xml:space="preserve"><value>Some tasks are discovered via the Event Log and can thus not be edited.
-Run as admin if you want to edit them.</value></data>
-  <data name="OnboardingBackButton.Content" xml:space="preserve"><value>Back</value></data>
-  <data name="OnboardingNextButton.Content" xml:space="preserve"><value>Next</value></data>
-  <data name="Onboarding.Step1.Title" xml:space="preserve"><value>Welcome to FluentTaskScheduler</value></data>
-  <data name="Onboarding.Step1.Body" xml:space="preserve"><value>Manage Windows Task Scheduler with a modern, fluent interface — no XML, no fuss.</value></data>
-  <data name="Onboarding.Step2.Title" xml:space="preserve"><value>Create your first task</value></data>
-  <data name="Onboarding.Step2.Body" xml:space="preserve"><value>Hit + New Task to schedule any program, script, or command to run automatically — daily, on login, on an event, and more.</value></data>
-  <data name="Onboarding.Step3.Title" xml:space="preserve"><value>Organise with folders</value></data>
-  <data name="Onboarding.Step3.Body" xml:space="preserve"><value>Group related tasks into folders using the sidebar, just like Windows Explorer. Your last folder is remembered across restarts.</value></data>
-  <data name="Onboarding.Step4.Title" xml:space="preserve"><value>Track history &amp; status</value></data>
-  <data name="Onboarding.Step4.Body" xml:space="preserve"><value>Click any task to see its run history, success and failure counts, and live running status — all in one place.</value></data>
-  <data name="Onboarding.Step5.Title" xml:space="preserve"><value>Always up to date</value></data>
-  <data name="Onboarding.Step5.Body" xml:space="preserve"><value>FluentTaskScheduler checks for updates automatically every time it starts. You can also trigger a manual check at any time from Settings → About → Check for Updates.</value></data>
-  <data name="Onboarding.Step6.Title" xml:space="preserve"><value>Discover existing tasks</value></data>
-  <data name="Onboarding.Step6.Body" xml:space="preserve"><value>Use Task Discovery to scan the Windows Event Log and automatically import tasks created by other applications — no manual recreation needed.</value></data>
-  <data name="Onboarding.Step7.Title" xml:space="preserve"><value>Tune it to your liking</value></data>
-  <data name="Onboarding.Step7.Body" xml:space="preserve"><value>Head to Settings to enable Mica backdrop, minimise to tray, configure logging, run on startup, and more.</value></data>
-  <data name="WhatsNewDialog.CloseButtonText" xml:space="preserve"><value>Got it</value></data>
-  <data name="WhatsNewViewOnGitHub.Text" xml:space="preserve"><value>View full release on GitHub</value></data>
+  <data name="Settings.UpToDate.Title" xml:space="preserve"><value>Up to Date</value></data>
+  <data name="Settings.UpToDate.Content" xml:space="preserve"><value>You're already running the latest version.</value></data>
 </root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <data name="AppHeader.Header" xml:space="preserve"><value>计划任务</value></data>
+  <data name="NewTaskButton.Text" xml:space="preserve"><value>新建任务</value></data>
+  <data name="NavAllTasks.Content" xml:space="preserve"><value>全部任务</value></data>
+  <data name="NavRunning.Content" xml:space="preserve"><value>运行中</value></data>
+  <data name="NavEnabled.Content" xml:space="preserve"><value>已启用</value></data>
+  <data name="RefreshButton.Content" xml:space="preserve"><value>刷新</value></data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>搜索任务...</value></data>
+  <data name="TaskNameHeader.Header" xml:space="preserve"><value>任务名称</value></data>
+  <data name="DescriptionHeader.Header" xml:space="preserve"><value>描述</value></data>
+  <data name="AuthorHeader.Header" xml:space="preserve"><value>作者</value></data>
+  <data name="EnabledSwitch.Header" xml:space="preserve"><value>启用</value></data>
+  <data name="ActionTitle.Text" xml:space="preserve"><value>操作</value></data>
+  <data name="ProgramScriptHeader.Header" xml:space="preserve"><value>程序/脚本</value></data>
+  <data name="BrowseButton.Content" xml:space="preserve"><value>浏览...</value></data>
+  <data name="ArgumentsHeader.Header" xml:space="preserve"><value>参数（可选）</value></data>
+  <data name="DialogTitle.Text" xml:space="preserve"><value>添加或编辑任务</value></data>
+  <data name="TriggerTitle.Text" xml:space="preserve"><value>触发器</value></data>
+  <data name="TriggerTypeHeader.Header" xml:space="preserve"><value>触发类型</value></data>
+  <data name="TimeHeader.Header" xml:space="preserve"><value>时间（HH:mm）</value></data>
+  <data name="RepetitionTitle.Text" xml:space="preserve"><value>重复</value></data>
+  <data name="RepetitionIntervalHeader.Header" xml:space="preserve"><value>每隔</value></data>
+  <data name="RepetitionDurationHeader.Header" xml:space="preserve"><value>持续时长</value></data>
+  <data name="ConditionsTitle.Text" xml:space="preserve"><value>条件</value></data>
+  <data name="ConditionIdle.Content" xml:space="preserve"><value>计算机空闲时</value></data>
+  <data name="ConditionAC.Content" xml:space="preserve"><value>仅在交流电源下</value></data>
+  <data name="ConditionNetwork.Content" xml:space="preserve"><value>网络可用时</value></data>
+  <data name="ConditionWake.Content" xml:space="preserve"><value>唤醒计算机以运行任务</value></data>
+  <data name="ConditionBattery.Content" xml:space="preserve"><value>切换到电池供电时停止</value></data>
+  <data name="SettingsTitle.Text" xml:space="preserve"><value>设置</value></data>
+  <data name="StopIfRunsLongerHeader.Header" xml:space="preserve"><value>任务运行超过以下时长后停止</value></data>
+  <data name="RunIfMissed.Content" xml:space="preserve"><value>错过计划启动后尽快运行任务</value></data>
+  <data name="RestartOnFailure.Content" xml:space="preserve"><value>任务失败时每隔以下时间重启：</value></data>
+  <data name="RestartCountText1.Text" xml:space="preserve"><value>最多重试：</value></data>
+  <data name="RestartCountText2.Text" xml:space="preserve"><value>次</value></data>
+  <data name="CancelButton.CloseButtonText" xml:space="preserve"><value>取消</value></data>
+  <data name="SaveButton.PrimaryButtonText" xml:space="preserve"><value>保存</value></data>
+  <data name="CloseButton.CloseButtonText" xml:space="preserve"><value>关闭</value></data>
+  <data name="RunNowButton.Content" xml:space="preserve"><value>立即运行</value></data>
+  <data name="StopButton.Content" xml:space="preserve"><value>停止</value></data>
+  <data name="DeleteButton.Content" xml:space="preserve"><value>删除</value></data>
+  <data name="ExportButton.Content" xml:space="preserve"><value>导出</value></data>
+  <data name="EditButton.Content" xml:space="preserve"><value>编辑</value></data>
+
+  <data name="SettingsHeader.Text" xml:space="preserve"><value>设置</value></data>
+  <data name="AppearanceHeader.Text" xml:space="preserve"><value>外观</value></data>
+  <data name="ThemeCombo.Header" xml:space="preserve"><value>应用主题</value></data>
+  <data name="ThemeDefault.Content" xml:space="preserve"><value>跟随系统</value></data>
+  <data name="ThemeLight.Content" xml:space="preserve"><value>浅色</value></data>
+  <data name="ThemeDark.Content" xml:space="preserve"><value>深色</value></data>
+  <data name="OledToggle.Header" xml:space="preserve"><value>OLED 模式</value></data>
+  <data name="OledHint.Text" xml:space="preserve"><value>仅在深色主题时可用。</value></data>
+  <data name="LanguageHeader.Text" xml:space="preserve"><value>语言</value></data>
+  <data name="LanguageCombo.Header" xml:space="preserve"><value>选择语言</value></data>
+  <data name="LanguageHint.Text" xml:space="preserve"><value>注意：语言切换需要重启应用。</value></data>
+  <data name="GeneralHeader.Text" xml:space="preserve"><value>通用</value></data>
+  <data name="ConfirmDelete.Header" xml:space="preserve"><value>删除任务前确认</value></data>
+  <data name="AboutHeader.Text" xml:space="preserve"><value>关于</value></data>
+  <data name="AboutTitle.Text" xml:space="preserve"><value>Fluent Task Scheduler</value></data>
+  <data name="AboutBuilt.Text" xml:space="preserve"><value>基于 WinUI 3 构建</value></data>
+
+  <data name="Dialog.Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Dialog.Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Dialog.OK" xml:space="preserve"><value>确定</value></data>
+  <data name="Dialog.Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="Dialog.Import" xml:space="preserve"><value>导入</value></data>
+  <data name="Dialog.Create" xml:space="preserve"><value>创建</value></data>
+  <data name="Dialog.Rename" xml:space="preserve"><value>重命名</value></data>
+  <data name="Dialog.RestartNow" xml:space="preserve"><value>立即重启</value></data>
+  <data name="Dialog.Later" xml:space="preserve"><value>稍后</value></data>
+  <data name="Dialog.Next" xml:space="preserve"><value>下一步</value></data>
+  <data name="Dialog.GetStarted" xml:space="preserve"><value>开始使用</value></data>
+
+  <data name="App.UnhandledException.Title" xml:space="preserve"><value>未处理异常</value></data>
+  <data name="App.UpdateAvailable.Title" xml:space="preserve"><value>发现更新</value></data>
+  <data name="App.UpdateAvailable.Content" xml:space="preserve"><value>版本 {0} 已下载完成并可安装。
+是否立即重启以应用更新？</value></data>
+
+  <data name="Main.HistoryCopied" xml:space="preserve"><value>✅ 已复制！</value></data>
+  <data name="Main.HistoryCopy" xml:space="preserve"><value>📋 复制</value></data>
+  <data name="Main.ConfirmDelete.Title" xml:space="preserve"><value>确认删除</value></data>
+  <data name="Main.ConfirmDelete.Content" xml:space="preserve"><value>确定要删除“{0}”吗？</value></data>
+  <data name="Main.ImportTask.Title" xml:space="preserve"><value>导入任务</value></data>
+  <data name="Main.ImportTask.SelectFolder" xml:space="preserve"><value>请选择要导入到的文件夹：</value></data>
+  <data name="Main.AnyNetwork" xml:space="preserve"><value>任意网络</value></data>
+  <data name="Main.PermissionEnableDenied" xml:space="preserve"><value>当前账户没有权限启用以下任务：
+
+{0}
+
+这些任务受保护，即使管理员权限也无法修改。</value></data>
+  <data name="Main.PermissionDisableDenied" xml:space="preserve"><value>当前账户没有权限禁用以下任务：
+
+{0}
+
+这些任务受保护，即使管理员权限也无法修改。</value></data>
+  <data name="Main.BatchDelete.Content" xml:space="preserve"><value>确定删除 {0} 个任务吗？</value></data>
+  <data name="Main.NewFolder.Title" xml:space="preserve"><value>新建文件夹</value></data>
+  <data name="Main.NewFolder.NamePlaceholder" xml:space="preserve"><value>名称</value></data>
+  <data name="Main.RenameFolder.Title" xml:space="preserve"><value>重命名文件夹</value></data>
+  <data name="Main.RenameFolder.NamePlaceholder" xml:space="preserve"><value>新名称</value></data>
+  <data name="Main.DeleteFolder.Title" xml:space="preserve"><value>删除文件夹</value></data>
+  <data name="Main.DeleteFolder.Content" xml:space="preserve"><value>确定删除“{0}”及其中全部任务吗？</value></data>
+  <data name="Main.MoveTasksPartialError" xml:space="preserve"><value>部分任务移动失败：
+
+</value></data>
+  <data name="Main.MoveFolderError" xml:space="preserve"><value>移动文件夹失败：{0}</value></data>
+  <data name="Main.Error.Title" xml:space="preserve"><value>错误</value></data>
+
+  <data name="ScriptLibrary.DeleteTemplate.Title" xml:space="preserve"><value>删除模板</value></data>
+  <data name="ScriptLibrary.DeleteTemplate.Content" xml:space="preserve"><value>确定删除“{0}”吗？</value></data>
+
+  <data name="SettingsLanguageTitle.Text" xml:space="preserve"><value>语言</value></data>
+  <data name="SettingsLanguageHint.Text" xml:space="preserve"><value>选择界面语言。重启应用后将完全生效。</value></data>
+  <data name="SettingsLanguageEnglish.Content" xml:space="preserve"><value>English</value></data>
+  <data name="SettingsLanguageChinese.Content" xml:space="preserve"><value>简体中文</value></data>
+  <data name="Settings.Language.Changed.Title" xml:space="preserve"><value>语言已更新</value></data>
+  <data name="Settings.Language.Changed.Content" xml:space="preserve"><value>语言偏好已保存。请重启应用以应用全部文字变更。</value></data>
+  <data name="Settings.Export.Success.Title" xml:space="preserve"><value>导出成功</value></data>
+  <data name="Settings.Export.Success.Content" xml:space="preserve"><value>设置已导出到：
+{0}</value></data>
+  <data name="Settings.Export.Failed.Title" xml:space="preserve"><value>导出失败</value></data>
+  <data name="Settings.Import.Success.Title" xml:space="preserve"><value>导入成功</value></data>
+  <data name="Settings.Import.Success.Content" xml:space="preserve"><value>设置已恢复，部分变更可能需要重启应用。</value></data>
+  <data name="Settings.Import.Failed.Title" xml:space="preserve"><value>导入失败</value></data>
+  <data name="Settings.WhatsNew.Title" xml:space="preserve"><value>更新说明</value></data>
+  <data name="Settings.WhatsNew.FetchFailed" xml:space="preserve"><value>无法获取发行说明，请检查网络后重试。</value></data>
+  <data name="Settings.Update.ErrorTitle" xml:space="preserve"><value>更新检查失败</value></data>
+  <data name="Settings.Update.ErrorContent" xml:space="preserve"><value>检查更新时发生错误：
+{0}</value></data>
+  <data name="Settings.Update.UpToDate.Title" xml:space="preserve"><value>已是最新版本</value></data>
+  <data name="Settings.Update.UpToDate.Content" xml:space="preserve"><value>当前已经是最新版本。</value></data>
+  <data name="Settings.Update.Available.Title" xml:space="preserve"><value>发现更新</value></data>
+  <data name="Settings.Update.Available.Content" xml:space="preserve"><value>版本 {0} 已下载完成并可安装。
+是否立即重启以应用更新？</value></data>
+
+  <data name="OnboardingHint.Text" xml:space="preserve"><value>你可以随时在设置中再次查看此引导。</value></data>
+  <data name="OnboardingWarn.Text" xml:space="preserve"><value>部分任务通过事件日志发现，因此不可编辑。
+若要编辑，请使用管理员身份运行。</value></data>
+  <data name="OnboardingBackButton.Content" xml:space="preserve"><value>上一步</value></data>
+  <data name="OnboardingNextButton.Content" xml:space="preserve"><value>下一步</value></data>
+  <data name="Onboarding.Step1.Title" xml:space="preserve"><value>欢迎使用 FluentTaskScheduler</value></data>
+  <data name="Onboarding.Step1.Body" xml:space="preserve"><value>使用现代 Fluent 界面管理 Windows 任务计划程序——无需 XML，简单高效。</value></data>
+  <data name="Onboarding.Step2.Title" xml:space="preserve"><value>创建你的第一个任务</value></data>
+  <data name="Onboarding.Step2.Body" xml:space="preserve"><value>点击“新建任务”即可自动调度任意程序、脚本或命令——支持每日、登录时、事件触发等。</value></data>
+  <data name="Onboarding.Step3.Title" xml:space="preserve"><value>使用文件夹组织任务</value></data>
+  <data name="Onboarding.Step3.Body" xml:space="preserve"><value>像资源管理器一样在侧栏按文件夹分组任务，应用会记住你上次所在文件夹。</value></data>
+  <data name="Onboarding.Step4.Title" xml:space="preserve"><value>跟踪历史与状态</value></data>
+  <data name="Onboarding.Step4.Body" xml:space="preserve"><value>点击任意任务即可查看运行历史、成功/失败次数与实时状态。</value></data>
+  <data name="Onboarding.Step5.Title" xml:space="preserve"><value>始终保持最新</value></data>
+  <data name="Onboarding.Step5.Body" xml:space="preserve"><value>应用启动时会自动检查更新，你也可以在 设置 → 关于 中手动检查更新。</value></data>
+  <data name="Onboarding.Step6.Title" xml:space="preserve"><value>发现已有任务</value></data>
+  <data name="Onboarding.Step6.Body" xml:space="preserve"><value>通过任务发现功能扫描事件日志，自动导入其他应用创建的任务，无需手动重建。</value></data>
+  <data name="Onboarding.Step7.Title" xml:space="preserve"><value>按你的偏好定制</value></data>
+  <data name="Onboarding.Step7.Body" xml:space="preserve"><value>在设置中可启用 Mica、最小化到托盘、配置日志、开机启动等功能。</value></data>
+
+  <data name="WhatsNewDialog.CloseButtonText" xml:space="preserve"><value>知道了</value></data>
+  <data name="WhatsNewViewOnGitHub.Text" xml:space="preserve"><value>在 GitHub 查看完整发布说明</value></data>
+</root>

--- a/Strings/zh-CN/Resources.resw
+++ b/Strings/zh-CN/Resources.resw
@@ -46,10 +46,18 @@
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 
   <data name="AppHeader.Header" xml:space="preserve"><value>计划任务</value></data>
   <data name="NewTaskButton.Text" xml:space="preserve"><value>新建任务</value></data>
@@ -71,19 +79,19 @@
   <data name="TriggerTypeHeader.Header" xml:space="preserve"><value>触发类型</value></data>
   <data name="TimeHeader.Header" xml:space="preserve"><value>时间（HH:mm）</value></data>
   <data name="RepetitionTitle.Text" xml:space="preserve"><value>重复</value></data>
-  <data name="RepetitionIntervalHeader.Header" xml:space="preserve"><value>每隔</value></data>
+  <data name="RepetitionIntervalHeader.Header" xml:space="preserve"><value>任务重复间隔</value></data>
   <data name="RepetitionDurationHeader.Header" xml:space="preserve"><value>持续时长</value></data>
   <data name="ConditionsTitle.Text" xml:space="preserve"><value>条件</value></data>
-  <data name="ConditionIdle.Content" xml:space="preserve"><value>计算机空闲时</value></data>
-  <data name="ConditionAC.Content" xml:space="preserve"><value>仅在交流电源下</value></data>
-  <data name="ConditionNetwork.Content" xml:space="preserve"><value>网络可用时</value></data>
-  <data name="ConditionWake.Content" xml:space="preserve"><value>唤醒计算机以运行任务</value></data>
+  <data name="ConditionIdle.Content" xml:space="preserve"><value>计算机空闲</value></data>
+  <data name="ConditionAC.Content" xml:space="preserve"><value>接通交流电源</value></data>
+  <data name="ConditionNetwork.Content" xml:space="preserve"><value>网络可用</value></data>
+  <data name="ConditionWake.Content" xml:space="preserve"><value>唤醒计算机以运行此任务</value></data>
   <data name="ConditionBattery.Content" xml:space="preserve"><value>切换到电池供电时停止</value></data>
   <data name="SettingsTitle.Text" xml:space="preserve"><value>设置</value></data>
-  <data name="StopIfRunsLongerHeader.Header" xml:space="preserve"><value>任务运行超过以下时长后停止</value></data>
-  <data name="RunIfMissed.Content" xml:space="preserve"><value>错过计划启动后尽快运行任务</value></data>
-  <data name="RestartOnFailure.Content" xml:space="preserve"><value>任务失败时每隔以下时间重启：</value></data>
-  <data name="RestartCountText1.Text" xml:space="preserve"><value>最多重试：</value></data>
+  <data name="StopIfRunsLongerHeader.Header" xml:space="preserve"><value>若任务运行超过以下时长则停止</value></data>
+  <data name="RunIfMissed.Content" xml:space="preserve"><value>错过计划启动时间后尽快运行任务</value></data>
+  <data name="RestartOnFailure.Content" xml:space="preserve"><value>任务失败时，每隔以下时间重启：</value></data>
+  <data name="RestartCountText1.Text" xml:space="preserve"><value>最多重启尝试：</value></data>
   <data name="RestartCountText2.Text" xml:space="preserve"><value>次</value></data>
   <data name="CancelButton.CloseButtonText" xml:space="preserve"><value>取消</value></data>
   <data name="SaveButton.PrimaryButtonText" xml:space="preserve"><value>保存</value></data>
@@ -101,110 +109,107 @@
   <data name="ThemeLight.Content" xml:space="preserve"><value>浅色</value></data>
   <data name="ThemeDark.Content" xml:space="preserve"><value>深色</value></data>
   <data name="OledToggle.Header" xml:space="preserve"><value>OLED 模式</value></data>
-  <data name="OledHint.Text" xml:space="preserve"><value>仅在深色主题时可用。</value></data>
+  <data name="OledHint.Text" xml:space="preserve"><value>OLED 模式仅在深色主题下可用。</value></data>
   <data name="LanguageHeader.Text" xml:space="preserve"><value>语言</value></data>
   <data name="LanguageCombo.Header" xml:space="preserve"><value>选择语言</value></data>
-  <data name="LanguageHint.Text" xml:space="preserve"><value>注意：语言切换需要重启应用。</value></data>
+  <data name="LanguageHint.Text" xml:space="preserve"><value>注意：语言变更可能需要重启。</value></data>
   <data name="GeneralHeader.Text" xml:space="preserve"><value>通用</value></data>
   <data name="ConfirmDelete.Header" xml:space="preserve"><value>删除任务前确认</value></data>
   <data name="AboutHeader.Text" xml:space="preserve"><value>关于</value></data>
   <data name="AboutTitle.Text" xml:space="preserve"><value>Fluent Task Scheduler</value></data>
   <data name="AboutBuilt.Text" xml:space="preserve"><value>基于 WinUI 3 构建</value></data>
 
-  <data name="Dialog.Close" xml:space="preserve"><value>关闭</value></data>
-  <data name="Dialog.Cancel" xml:space="preserve"><value>取消</value></data>
-  <data name="Dialog.OK" xml:space="preserve"><value>确定</value></data>
-  <data name="Dialog.Delete" xml:space="preserve"><value>删除</value></data>
-  <data name="Dialog.Import" xml:space="preserve"><value>导入</value></data>
-  <data name="Dialog.Create" xml:space="preserve"><value>创建</value></data>
-  <data name="Dialog.Rename" xml:space="preserve"><value>重命名</value></data>
-  <data name="Dialog.RestartNow" xml:space="preserve"><value>立即重启</value></data>
-  <data name="Dialog.Later" xml:space="preserve"><value>稍后</value></data>
-  <data name="Dialog.Next" xml:space="preserve"><value>下一步</value></data>
-  <data name="Dialog.GetStarted" xml:space="preserve"><value>开始使用</value></data>
-
-  <data name="App.UnhandledException.Title" xml:space="preserve"><value>未处理异常</value></data>
-  <data name="App.UpdateAvailable.Title" xml:space="preserve"><value>发现更新</value></data>
-  <data name="App.UpdateAvailable.Content" xml:space="preserve"><value>版本 {0} 已下载完成并可安装。
+  <data name="App.WindowTitle" xml:space="preserve"><value>FluentTaskScheduler</value></data>
+  <data name="Dialog.Common.OK" xml:space="preserve"><value>确定</value></data>
+  <data name="Dialog.Common.Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Dialog.Common.Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Dialog.Common.Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="Dialog.Common.Import" xml:space="preserve"><value>导入</value></data>
+  <data name="Dialog.Common.Create" xml:space="preserve"><value>创建</value></data>
+  <data name="Dialog.Common.Rename" xml:space="preserve"><value>重命名</value></data>
+  <data name="Dialog.Common.Later" xml:space="preserve"><value>稍后</value></data>
+  <data name="Dialog.Common.Save" xml:space="preserve"><value>保存</value></data>
+  <data name="Dialog.Error.Title" xml:space="preserve"><value>错误</value></data>
+  <data name="Dialog.ConfirmDelete.Title" xml:space="preserve"><value>确认删除</value></data>
+  <data name="Dialog.DeleteTask.ContentFormat" xml:space="preserve"><value>确定要删除“{0}”吗？</value></data>
+  <data name="Dialog.BatchDelete.ContentFormat" xml:space="preserve"><value>要删除 {0} 个任务吗？</value></data>
+  <data name="Dialog.ImportTask.Title" xml:space="preserve"><value>导入任务</value></data>
+  <data name="Dialog.ImportTask.SelectFolder" xml:space="preserve"><value>请选择导入任务的目标文件夹：</value></data>
+  <data name="Dialog.NewFolder.Title" xml:space="preserve"><value>新建文件夹</value></data>
+  <data name="Dialog.NewFolder.NamePlaceholder" xml:space="preserve"><value>名称</value></data>
+  <data name="Dialog.RenameFolder.Title" xml:space="preserve"><value>重命名文件夹</value></data>
+  <data name="Dialog.RenameFolder.NewNamePlaceholder" xml:space="preserve"><value>新名称</value></data>
+  <data name="Dialog.DeleteFolder.Title" xml:space="preserve"><value>删除文件夹</value></data>
+  <data name="Dialog.DeleteFolder.ContentFormat" xml:space="preserve"><value>删除“{0}”及其所有任务？</value></data>
+  <data name="Dialog.UpdateAvailable.Title" xml:space="preserve"><value>有可用更新</value></data>
+  <data name="Dialog.UpdateAvailable.ContentFormat" xml:space="preserve"><value>版本 {0} 已下载并可安装。
 是否立即重启以应用更新？</value></data>
+  <data name="Dialog.UpdateAvailable.RestartNow" xml:space="preserve"><value>立即重启</value></data>
 
-  <data name="Main.HistoryCopied" xml:space="preserve"><value>✅ 已复制！</value></data>
-  <data name="Main.HistoryCopy" xml:space="preserve"><value>📋 复制</value></data>
-  <data name="Main.ConfirmDelete.Title" xml:space="preserve"><value>确认删除</value></data>
-  <data name="Main.ConfirmDelete.Content" xml:space="preserve"><value>确定要删除“{0}”吗？</value></data>
-  <data name="Main.ImportTask.Title" xml:space="preserve"><value>导入任务</value></data>
-  <data name="Main.ImportTask.SelectFolder" xml:space="preserve"><value>请选择要导入到的文件夹：</value></data>
-  <data name="Main.AnyNetwork" xml:space="preserve"><value>任意网络</value></data>
-  <data name="Main.PermissionEnableDenied" xml:space="preserve"><value>当前账户没有权限启用以下任务：
+  <data name="Main.Nav.Dashboard" xml:space="preserve"><value>仪表盘</value></data>
+  <data name="Main.Nav.ScriptLibrary" xml:space="preserve"><value>脚本库</value></data>
+  <data name="Main.Nav.NewTask" xml:space="preserve"><value>新建任务</value></data>
+  <data name="Main.Nav.AllTasks" xml:space="preserve"><value>全部任务</value></data>
+  <data name="Main.Nav.Running" xml:space="preserve"><value>运行中</value></data>
+  <data name="Main.Nav.Enabled" xml:space="preserve"><value>已启用</value></data>
+  <data name="Main.Nav.Disabled" xml:space="preserve"><value>已禁用</value></data>
+  <data name="Main.Nav.Settings" xml:space="preserve"><value>设置</value></data>
+  <data name="Main.Header.ScheduledTasks" xml:space="preserve"><value>计划任务</value></data>
+  <data name="Main.Header.Settings" xml:space="preserve"><value>设置</value></data>
+  <data name="Main.Header.Dashboard" xml:space="preserve"><value>仪表盘</value></data>
+  <data name="Main.Header.ScriptLibrary" xml:space="preserve"><value>脚本库</value></data>
+  <data name="Main.Toolbar.ImportTask" xml:space="preserve"><value>导入任务</value></data>
+  <data name="Main.Toolbar.Refresh" xml:space="preserve"><value>刷新</value></data>
+  <data name="Main.Toolbar.ShortcutsButton" xml:space="preserve"><value>?</value></data>
+  <data name="Main.Toolbar.ShortcutsTooltip" xml:space="preserve"><value>快捷键（F1）</value></data>
+  <data name="Main.Toolbar.SortButton" xml:space="preserve"><value>排序 ↕</value></data>
+  <data name="Main.Toolbar.SortActiveFormat" xml:space="preserve"><value>排序 {0} {1}</value></data>
+  <data name="Main.Sort.Name" xml:space="preserve"><value>名称</value></data>
+  <data name="Main.Sort.Status" xml:space="preserve"><value>状态</value></data>
+  <data name="Main.Sort.NextRun" xml:space="preserve"><value>下次运行</value></data>
+  <data name="Main.Sort.LastRun" xml:space="preserve"><value>上次运行</value></data>
+  <data name="Main.Sort.Clear" xml:space="preserve"><value>清除排序</value></data>
+  <data name="Main.Task.RunNow" xml:space="preserve"><value>立即运行</value></data>
+  <data name="Main.Task.Stop" xml:space="preserve"><value>停止</value></data>
+  <data name="Main.Task.Edit" xml:space="preserve"><value>编辑</value></data>
+  <data name="Main.Task.Export" xml:space="preserve"><value>导出</value></data>
+  <data name="Main.Task.Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="Main.HistoryDialog.Title" xml:space="preserve"><value>任务历史</value></data>
+  <data name="Main.History.Copy" xml:space="preserve"><value>📋 复制</value></data>
+  <data name="Main.History.Copied" xml:space="preserve"><value>✅ 已复制！</value></data>
+  <data name="Main.ShortcutsDialog.Title" xml:space="preserve"><value>键盘快捷键</value></data>
+  <data name="Main.AdminDragWarning.Title" xml:space="preserve"><value>拖放受限</value></data>
+  <data name="Main.AdminDragWarning.Message" xml:space="preserve"><value>应用以管理员身份运行时，Windows 不支持拖放操作。</value></data>
+  <data name="Main.Network.Any" xml:space="preserve"><value>任意网络</value></data>
 
-{0}
-
-这些任务受保护，即使管理员权限也无法修改。</value></data>
-  <data name="Main.PermissionDisableDenied" xml:space="preserve"><value>当前账户没有权限禁用以下任务：
-
-{0}
-
-这些任务受保护，即使管理员权限也无法修改。</value></data>
-  <data name="Main.BatchDelete.Content" xml:space="preserve"><value>确定删除 {0} 个任务吗？</value></data>
-  <data name="Main.NewFolder.Title" xml:space="preserve"><value>新建文件夹</value></data>
-  <data name="Main.NewFolder.NamePlaceholder" xml:space="preserve"><value>名称</value></data>
-  <data name="Main.RenameFolder.Title" xml:space="preserve"><value>重命名文件夹</value></data>
-  <data name="Main.RenameFolder.NamePlaceholder" xml:space="preserve"><value>新名称</value></data>
-  <data name="Main.DeleteFolder.Title" xml:space="preserve"><value>删除文件夹</value></data>
-  <data name="Main.DeleteFolder.Content" xml:space="preserve"><value>确定删除“{0}”及其中全部任务吗？</value></data>
-  <data name="Main.MoveTasksPartialError" xml:space="preserve"><value>部分任务移动失败：
-
-</value></data>
-  <data name="Main.MoveFolderError" xml:space="preserve"><value>移动文件夹失败：{0}</value></data>
-  <data name="Main.Error.Title" xml:space="preserve"><value>错误</value></data>
-
-  <data name="ScriptLibrary.DeleteTemplate.Title" xml:space="preserve"><value>删除模板</value></data>
-  <data name="ScriptLibrary.DeleteTemplate.Content" xml:space="preserve"><value>确定删除“{0}”吗？</value></data>
-
-  <data name="SettingsLanguageTitle.Text" xml:space="preserve"><value>语言</value></data>
-  <data name="SettingsLanguageHint.Text" xml:space="preserve"><value>选择界面语言。重启应用后将完全生效。</value></data>
-  <data name="SettingsLanguageEnglish.Content" xml:space="preserve"><value>English</value></data>
-  <data name="SettingsLanguageChinese.Content" xml:space="preserve"><value>简体中文</value></data>
-  <data name="Settings.Language.Changed.Title" xml:space="preserve"><value>语言已更新</value></data>
-  <data name="Settings.Language.Changed.Content" xml:space="preserve"><value>语言偏好已保存。请重启应用以应用全部文字变更。</value></data>
+  <data name="Settings.Nav.Appearance" xml:space="preserve"><value>外观</value></data>
+  <data name="Settings.Nav.Notifications" xml:space="preserve"><value>通知</value></data>
+  <data name="Settings.Nav.System" xml:space="preserve"><value>系统</value></data>
+  <data name="Settings.Nav.Advanced" xml:space="preserve"><value>高级</value></data>
+  <data name="Settings.Nav.Data" xml:space="preserve"><value>数据</value></data>
+  <data name="Settings.Nav.Categories" xml:space="preserve"><value>分类与标签</value></data>
+  <data name="Settings.Nav.About" xml:space="preserve"><value>关于</value></data>
+  <data name="Settings.Section.Appearance" xml:space="preserve"><value>外观</value></data>
+  <data name="Settings.Section.Notifications" xml:space="preserve"><value>通知</value></data>
+  <data name="Settings.Section.System" xml:space="preserve"><value>系统</value></data>
+  <data name="Settings.Section.Advanced" xml:space="preserve"><value>高级</value></data>
+  <data name="Settings.Section.Data" xml:space="preserve"><value>数据</value></data>
+  <data name="Settings.Section.Categories" xml:space="preserve"><value>分类与标签</value></data>
+  <data name="Settings.Section.About" xml:space="preserve"><value>关于</value></data>
+  <data name="Settings.Appearance.Language.Title" xml:space="preserve"><value>语言</value></data>
+  <data name="Settings.Appearance.Language.Description" xml:space="preserve"><value>选择应用显示语言。</value></data>
   <data name="Settings.Export.Success.Title" xml:space="preserve"><value>导出成功</value></data>
-  <data name="Settings.Export.Success.Content" xml:space="preserve"><value>设置已导出到：
+  <data name="Settings.Export.Success.ContentFormat" xml:space="preserve"><value>设置已导出到：
 {0}</value></data>
   <data name="Settings.Export.Failed.Title" xml:space="preserve"><value>导出失败</value></data>
   <data name="Settings.Import.Success.Title" xml:space="preserve"><value>导入成功</value></data>
-  <data name="Settings.Import.Success.Content" xml:space="preserve"><value>设置已恢复，部分变更可能需要重启应用。</value></data>
+  <data name="Settings.Import.Success.Content" xml:space="preserve"><value>设置已恢复。部分更改可能需要重启应用。</value></data>
   <data name="Settings.Import.Failed.Title" xml:space="preserve"><value>导入失败</value></data>
-  <data name="Settings.WhatsNew.Title" xml:space="preserve"><value>更新说明</value></data>
-  <data name="Settings.WhatsNew.FetchFailed" xml:space="preserve"><value>无法获取发行说明，请检查网络后重试。</value></data>
-  <data name="Settings.Update.ErrorTitle" xml:space="preserve"><value>更新检查失败</value></data>
-  <data name="Settings.Update.ErrorContent" xml:space="preserve"><value>检查更新时发生错误：
+  <data name="Settings.WhatsNew.Title" xml:space="preserve"><value>更新内容</value></data>
+  <data name="Settings.WhatsNew.FetchFailed" xml:space="preserve"><value>无法获取发行说明。请检查网络后重试。</value></data>
+  <data name="Settings.UpdateError.Title" xml:space="preserve"><value>更新错误</value></data>
+  <data name="Settings.UpdateError.ContentFormat" xml:space="preserve"><value>检查更新时发生错误：
 {0}</value></data>
-  <data name="Settings.Update.UpToDate.Title" xml:space="preserve"><value>已是最新版本</value></data>
-  <data name="Settings.Update.UpToDate.Content" xml:space="preserve"><value>当前已经是最新版本。</value></data>
-  <data name="Settings.Update.Available.Title" xml:space="preserve"><value>发现更新</value></data>
-  <data name="Settings.Update.Available.Content" xml:space="preserve"><value>版本 {0} 已下载完成并可安装。
-是否立即重启以应用更新？</value></data>
-
-  <data name="OnboardingHint.Text" xml:space="preserve"><value>你可以随时在设置中再次查看此引导。</value></data>
-  <data name="OnboardingWarn.Text" xml:space="preserve"><value>部分任务通过事件日志发现，因此不可编辑。
-若要编辑，请使用管理员身份运行。</value></data>
-  <data name="OnboardingBackButton.Content" xml:space="preserve"><value>上一步</value></data>
-  <data name="OnboardingNextButton.Content" xml:space="preserve"><value>下一步</value></data>
-  <data name="Onboarding.Step1.Title" xml:space="preserve"><value>欢迎使用 FluentTaskScheduler</value></data>
-  <data name="Onboarding.Step1.Body" xml:space="preserve"><value>使用现代 Fluent 界面管理 Windows 任务计划程序——无需 XML，简单高效。</value></data>
-  <data name="Onboarding.Step2.Title" xml:space="preserve"><value>创建你的第一个任务</value></data>
-  <data name="Onboarding.Step2.Body" xml:space="preserve"><value>点击“新建任务”即可自动调度任意程序、脚本或命令——支持每日、登录时、事件触发等。</value></data>
-  <data name="Onboarding.Step3.Title" xml:space="preserve"><value>使用文件夹组织任务</value></data>
-  <data name="Onboarding.Step3.Body" xml:space="preserve"><value>像资源管理器一样在侧栏按文件夹分组任务，应用会记住你上次所在文件夹。</value></data>
-  <data name="Onboarding.Step4.Title" xml:space="preserve"><value>跟踪历史与状态</value></data>
-  <data name="Onboarding.Step4.Body" xml:space="preserve"><value>点击任意任务即可查看运行历史、成功/失败次数与实时状态。</value></data>
-  <data name="Onboarding.Step5.Title" xml:space="preserve"><value>始终保持最新</value></data>
-  <data name="Onboarding.Step5.Body" xml:space="preserve"><value>应用启动时会自动检查更新，你也可以在 设置 → 关于 中手动检查更新。</value></data>
-  <data name="Onboarding.Step6.Title" xml:space="preserve"><value>发现已有任务</value></data>
-  <data name="Onboarding.Step6.Body" xml:space="preserve"><value>通过任务发现功能扫描事件日志，自动导入其他应用创建的任务，无需手动重建。</value></data>
-  <data name="Onboarding.Step7.Title" xml:space="preserve"><value>按你的偏好定制</value></data>
-  <data name="Onboarding.Step7.Body" xml:space="preserve"><value>在设置中可启用 Mica、最小化到托盘、配置日志、开机启动等功能。</value></data>
-
-  <data name="WhatsNewDialog.CloseButtonText" xml:space="preserve"><value>知道了</value></data>
-  <data name="WhatsNewViewOnGitHub.Text" xml:space="preserve"><value>在 GitHub 查看完整发布说明</value></data>
+  <data name="Settings.UpToDate.Title" xml:space="preserve"><value>已是最新版本</value></data>
+  <data name="Settings.UpToDate.Content" xml:space="preserve"><value>当前已运行最新版本。</value></data>
 </root>

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -87,10 +87,10 @@ namespace FluentTaskScheduler.ViewModels
             DailyHistory = new ObservableCollection<DailyChartPoint>();
             RunningTasksList = new ObservableCollection<RunningTaskInfo>();
             FailedTasksList = new ObservableCollection<FailedTaskInfo>();
-            AvailableTags = new ObservableCollection<FilterItem> { new FilterItem { Name = "All Tags", IsSelected = true } };
-            _selectedTag = "All Tags";
-            AvailableCategories = new ObservableCollection<FilterItem> { new FilterItem { Name = "All Categories", IsSelected = true } };
-            _selectedCategory = "All Categories";
+            AvailableTags = new ObservableCollection<FilterItem> { new FilterItem { Name = "全部标签", IsSelected = true } };
+            _selectedTag = "全部标签";
+            AvailableCategories = new ObservableCollection<FilterItem> { new FilterItem { Name = "全部分类", IsSelected = true } };
+            _selectedCategory = "全部分类";
         }
 
         public int RunningTasks
@@ -153,7 +153,7 @@ namespace FluentTaskScheduler.ViewModels
         public ObservableCollection<FilterItem> AvailableTags { get; }
         public ObservableCollection<FilterItem> AvailableCategories { get; }
 
-        private string _selectedTag = "All Tags";
+        private string _selectedTag = "全部标签";
         public string SelectedTag
         {
             get => _selectedTag;
@@ -161,7 +161,7 @@ namespace FluentTaskScheduler.ViewModels
             {
                 if (_selectedTag != value)
                 {
-                    _selectedTag = value ?? "All Tags";
+                    _selectedTag = value ?? "全部标签";
                     OnPropertyChanged();
 
                     foreach (var tag in AvailableTags) tag.IsSelected = (tag.Name == _selectedTag);
@@ -170,7 +170,7 @@ namespace FluentTaskScheduler.ViewModels
             }
         }
 
-        private string _selectedCategory = "All Categories";
+        private string _selectedCategory = "全部分类";
         public string SelectedCategory
         {
             get => _selectedCategory;
@@ -178,7 +178,7 @@ namespace FluentTaskScheduler.ViewModels
             {
                 if (_selectedCategory != value)
                 {
-                    _selectedCategory = value ?? "All Categories";
+                    _selectedCategory = value ?? "全部分类";
                     OnPropertyChanged();
 
                     foreach (var cat in AvailableCategories) cat.IsSelected = (cat.Name == _selectedCategory);
@@ -216,11 +216,11 @@ namespace FluentTaskScheduler.ViewModels
 
                     // 3. Filter tasks if needed
                     var allTasks = allTasksRaw;
-                    if (!string.IsNullOrEmpty(SelectedTag) && SelectedTag != "All Tags")
+                    if (!string.IsNullOrEmpty(SelectedTag) && SelectedTag != "全部标签")
                     {
                         allTasks = allTasks.Where(t => t.Tags != null && t.Tags.Contains(SelectedTag, StringComparer.OrdinalIgnoreCase)).ToList();
                     }
-                    if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All Categories")
+                    if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "全部分类")
                     {
                         allTasks = allTasks.Where(t => string.Equals(t.Category, SelectedCategory, StringComparison.OrdinalIgnoreCase)).ToList();
                     }
@@ -238,7 +238,7 @@ namespace FluentTaskScheduler.ViewModels
                         var actionCmd = task.ActionCommand;
                         var processName = "";
                         var processAlive = false;
-                        var processStatus = "Unknown";
+                        var processStatus = "未知";
 
                         if (!string.IsNullOrEmpty(actionCmd))
                         {
@@ -315,7 +315,7 @@ namespace FluentTaskScheduler.ViewModels
                                 DateTime.TryParse(h.Time, out var dt) && dt.Date == day);
                             return new DailyChartPoint
                             {
-                                Label = day == today ? "Today" : day.ToString("ddd"),
+                                Label = day == today ? "今天" : day.ToString("ddd"),
                                 Successes = dayEntries.Count(e => e.Result == "Task Completed"),
                                 Failures  = dayEntries.Count(e => e.Result != "Task Completed"
                                                                 && !string.IsNullOrEmpty(e.Result)),
@@ -376,7 +376,7 @@ namespace FluentTaskScheduler.ViewModels
 
                         // Update available tags
                         var currentTags = AvailableTags.Select(t => t.Name).ToList();
-                        var newTags = new List<string> { "All Tags" };
+                        var newTags = new List<string> { "全部标签" };
                         newTags.AddRange(uniqueTags);
 
                         if (!currentTags.SequenceEqual(newTags))
@@ -388,7 +388,7 @@ namespace FluentTaskScheduler.ViewModels
 
                         // Update available categories
                         var currentCats = AvailableCategories.Select(t => t.Name).ToList();
-                        var newCats = new List<string> { "All Categories" };
+                        var newCats = new List<string> { "全部分类" };
                         newCats.AddRange(uniqueCategories);
 
                         if (!currentCats.SequenceEqual(newCats))


### PR DESCRIPTION
## Summary
- Add and complete Simplified Chinese localization across key UI areas
- Improve localization coverage for Settings, Dashboard, Script Library, and New Task related flows
- Keep English fallback/resource structure in place

## Notes
This PR introduces Chinese i18n as a starting point.
If the community is interested, additional languages can be added following the same localization pattern.

# Screenshot

<img width="1682" height="994" alt="image" src="https://github.com/user-attachments/assets/b32fb758-1627-4130-a774-d156822bfd30" />

---

<img width="1681" height="1000" alt="image" src="https://github.com/user-attachments/assets/4245f26d-59df-4f48-9041-0d46a0c77448" />

